### PR TITLE
InputText, InputTextMultiline, InputFloat, InputInt

### DIFF
--- a/doc/source/guide/index.rst
+++ b/doc/source/guide/index.rst
@@ -11,6 +11,7 @@ usage guide
    window-flags
    treenode-flags
    selectable-flag
+   inputtext-flags
 
 .. visual-example::
     :title: Guide - hello world!

--- a/doc/source/guide/inputtext-flags.rst
+++ b/doc/source/guide/inputtext-flags.rst
@@ -1,7 +1,7 @@
 .. _guide-inputtext-flags:
 
 Using input text flags
-==================
+======================
 
 InpuText functions accept various flags to manage their behaviour.
 

--- a/doc/source/guide/inputtext-flags.rst
+++ b/doc/source/guide/inputtext-flags.rst
@@ -1,0 +1,28 @@
+.. _guide-inputtext-flags:
+
+Using input text flags
+==================
+
+InpuText functions accept various flags to manage their behaviour.
+
+List of all available input text flags (click to see documentation):
+
+.. _inputtext-flag-options:
+
+
+* :py:data:`imgui.INPUT_TEXT_CHARS_DECIMAL`
+* :py:data:`imgui.INPUT_TEXT_CHARS_HEXADECIMAL`
+* :py:data:`imgui.INPUT_TEXT_CHARS_UPPERCASE`
+* :py:data:`imgui.INPUT_TEXT_CHARS_NO_BLANK`
+* :py:data:`imgui.INPUT_TEXT_AUTO_SELECT_ALL`
+* :py:data:`imgui.INPUT_TEXT_ENTER_RETURNS_TRUE`
+* :py:data:`imgui.INPUT_TEXT_CALLBACK_COMPLETION`
+* :py:data:`imgui.INPUT_TEXT_CALLBACK_HISTORY`
+* :py:data:`imgui.INPUT_TEXT_CALLBACK_ALWAYS`
+* :py:data:`imgui.INPUT_TEXT_CALLBACK_CHAR_FILTER`
+* :py:data:`imgui.INPUT_TEXT_ALLOW_TAB_INPUT`
+* :py:data:`imgui.INPUT_TEXT_CTRL_ENTER_FOR_NEW_LINE`
+* :py:data:`imgui.INPUT_TEXT_NO_HORIZONTAL_SCROLL`
+* :py:data:`imgui.INPUT_TEXT_ALWAYS_INSERT_MODE`
+* :py:data:`imgui.INPUT_TEXT_READ_ONLY`
+* :py:data:`imgui.INPUT_TEXT_PASSWORD`

--- a/doc/source/guide/selectable-flag.rst
+++ b/doc/source/guide/selectable-flag.rst
@@ -1,7 +1,7 @@
 .. _guide-selectable-flags:
 
 Using selectable flags
-==================
+======================
 
 Selectable/Lists functions accept various flags to manage their behaviour.
 

--- a/doc/source/guide/treenode-flags.rst
+++ b/doc/source/guide/treenode-flags.rst
@@ -1,7 +1,7 @@
 .. _guide-treenode-flags:
 
 Using tree node flags
-==================
+=====================
 
 TreeNode functions accept various flags to manage their behaviour.
 

--- a/imgui/__init__.py
+++ b/imgui/__init__.py
@@ -144,3 +144,40 @@ TREE_NODE_BULLET = core.TREE_NODE_BULLET
 SELECTABLE_DONT_CLOSE_POPUPS = core.SELECTABLE_DONT_CLOSE_POPUPS
 SELECTABLE_SPAN_ALL_COLUMNS = core.SELECTABLE_SPAN_ALL_COLUMNS
 SELECTABLE_ALLOW_DOUBLE_CLICK = core.SELECTABLE_ALLOW_DOUBLE_CLICK
+
+#: Allow 0123456789.+-*/
+INPUT_TEXT_CHARS_DECIMAL = core.INPUT_TEXT_CHARS_DECIMAL
+#: Allow 0123456789ABCDEFabcdef
+INPUT_TEXT_CHARS_HEXADECIMAL = core.INPUT_TEXT_CHARS_HEXADECIMAL
+#: Turn a..z into A..Z
+INPUT_TEXT_CHARS_UPPERCASE = core.INPUT_TEXT_CHARS_UPPERCASE
+#: Filter out spaces, tabs
+INPUT_TEXT_CHARS_NO_BLANK = core.INPUT_TEXT_CHARS_NO_BLANK
+#: Select entire text when first taking mouse focus
+INPUT_TEXT_AUTO_SELECT_ALL = core.INPUT_TEXT_AUTO_SELECT_ALL
+#: Return 'true' when Enter is pressed (as opposed to when the
+#: # value was modified)
+INPUT_TEXT_ENTER_RETURNS_TRUE = core.INPUT_TEXT_ENTER_RETURNS_TRUE
+#: Call user function on pressing TAB (for completion handling)
+INPUT_TEXT_CALLBACK_COMPLETION = core.INPUT_TEXT_CALLBACK_COMPLETION
+#: Call user function on pressing Up/Down arrows (for history handling)
+INPUT_TEXT_CALLBACK_HISTORY = core.INPUT_TEXT_CALLBACK_HISTORY
+#: Call user function every time. User code may query cursor position,
+#: # modify text buffer.
+INPUT_TEXT_CALLBACK_ALWAYS = core.INPUT_TEXT_CALLBACK_ALWAYS
+#: Call user function to filter character. Modify data->EventChar to
+#: # replace/filter input, or return 1 to discard character.
+INPUT_TEXT_CALLBACK_CHAR_FILTER = core.INPUT_TEXT_CALLBACK_CHAR_FILTER
+#: Pressing TAB input a '\t' character into the text field
+INPUT_TEXT_ALLOW_TAB_INPUT = core.INPUT_TEXT_ALLOW_TAB_INPUT
+#: In multi-line mode, allow exiting edition by pressing Enter.
+#: # Ctrl+Enter to add new line (by default adds new lines with Enter).
+INPUT_TEXT_CTRL_ENTER_FOR_NEW_LINE = core.INPUT_TEXT_CTRL_ENTER_FOR_NEW_LINE
+#: Disable following the cursor horizontally
+INPUT_TEXT_NO_HORIZONTAL_SCROLL = core.INPUT_TEXT_NO_HORIZONTAL_SCROLL
+#: Insert mode
+INPUT_TEXT_ALWAYS_INSERT_MODE = core.INPUT_TEXT_ALWAYS_INSERT_MODE
+#: Read-only mode
+INPUT_TEXT_READ_ONLY = core.INPUT_TEXT_READ_ONLY
+#: Password mode, display all characters as '*'
+INPUT_TEXT_PASSWORD = core.INPUT_TEXT_PASSWORD

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -632,56 +632,56 @@ cdef extern from "imgui.h" namespace "ImGui":
     )
 
     # Widgets: Input with Keyboard
-    bool InputText(  # ✗
+    bool InputText(  # ✓
             const char* label, char* buf, size_t buf_size,
             # note: optional
             ImGuiInputTextFlags flags,
             ImGuiTextEditCallback callback, void* user_data
     )
-    bool InputTextMultiline(  # ✗
+    bool InputTextMultiline(  # ✓
             const char* label, char* buf, size_t buf_size,
             # note: optional
             const ImVec2& size, ImGuiInputTextFlags flags,
             ImGuiTextEditCallback callback, void* user_data
     )
-    bool InputFloat(  # ✗
+    bool InputFloat(  # ✓
             const char* label, float* v,
             # note: optional
             float step, float step_fast,
             int decimal_precision, ImGuiInputTextFlags extra_flags
     )
-    bool InputFloat2(  # ✗
+    bool InputFloat2(  # ✓
             const char* label, float v[2],
             # note: optional
             int decimal_precision, ImGuiInputTextFlags extra_flags
     )
-    bool InputFloat3(  # ✗
+    bool InputFloat3(  # ✓
             const char* label, float v[3],
             # note: optional
             int decimal_precision, ImGuiInputTextFlags extra_flags
     )
-    bool InputFloat4(  # ✗
+    bool InputFloat4(  # ✓
             const char* label, float v[4],
             # note: optional
             int decimal_precision, ImGuiInputTextFlags extra_flags
     )
-    bool InputInt(  # ✗
+    bool InputInt(  # ✓
             const char* label, int* v,
             # note: optional
             int step, int step_fast,
             ImGuiInputTextFlags extra_flags
     )
-    bool InputInt2(  # ✗
+    bool InputInt2(  # ✓
             const char* label, int v[2],
             # note: optional
             ImGuiInputTextFlags extra_flags
     )
-    bool InputInt3(  # ✗
+    bool InputInt3(  # ✓
             const char* label, int v[3],
             # note: optional
             ImGuiInputTextFlags extra_flags
     )
-    bool InputInt4(  # ✗
+    bool InputInt4(  # ✓
             const char* label, int v[4],
             # note: optional
             ImGuiInputTextFlags extra_flags

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -138,6 +138,10 @@ cdef bytes _bytes(str text):
     return <bytes>(text if PY_MAJOR_VERSION < 3 else text.encode('utf-8'))
 
 
+cdef str _from_bytes(bytes text):
+    return <str>(text if PY_MAJOR_VERSION < 3 else text.decode('utf-8'))
+
+
 cdef _cast_ImVec2_tuple(cimgui.ImVec2 vec):  # noqa
     return Vec2(vec.x, vec.y)
 
@@ -3293,8 +3297,15 @@ def drag_int4(
     ), (inout_values[0], inout_values[1], inout_values[2], inout_values[3])
 
 
-def input_text(str label, str value, cimgui.ImGuiInputTextFlags flags=0):
+def input_text(
+    str label,
+    str value,
+    int buffer_length,
+    cimgui.ImGuiInputTextFlags flags=0
+):
     """Display text input widget.
+
+    ``buffer_length`` is the maximum allowed length of the content.
 
     .. visual-example::
         :auto_layout:
@@ -3303,7 +3314,11 @@ def input_text(str label, str value, cimgui.ImGuiInputTextFlags flags=0):
 
         text_val = 'Please, type the coefficient here.'
         imgui.begin("Example: text input")
-        changed, text_val = imgui.input_text('Amount:', text_val)
+        changed, text_val = imgui.input_text(
+            'Amount:',
+            text_val,
+            256
+        )
         imgui.text('You wrote:')
         imgui.same_line()
         imgui.text(text_val)
@@ -3312,6 +3327,7 @@ def input_text(str label, str value, cimgui.ImGuiInputTextFlags flags=0):
     Args:
         label (str): widget label.
         value (str): textbox value
+        buffer_length (int): length of the content buffer
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
 
@@ -3329,28 +3345,31 @@ def input_text(str label, str value, cimgui.ImGuiInputTextFlags flags=0):
             void* user_data = NULL
         )
     """
+    value_bytes = _bytes(value)
+    value_len = len(value)
 
-    # return changed, bytes_text.decode('utf-8')
-
-    cdef bytes bytes_text = _bytes(value)
-    cdef char inout_text[2056]
-    strcpy(inout_text, bytes_text)
+    cdef char* inout_text = NULL
+    temp_value = value_bytes[:value_len]
+    inout_text = <bytes>temp_value
 
     changed = cimgui.InputText(
-        _bytes(label), inout_text, sizeof(inout_text), flags, NULL, NULL
+        _bytes(label), inout_text, buffer_length, flags, NULL, NULL
     )
 
-    return changed, bytes_text.decode('utf-8')
+    return changed, _from_bytes(inout_text)
 
 
 def input_text_multiline(
     str label,
     str value,
+    int buffer_length,
     float width=0,
     float height=0,
     cimgui.ImGuiInputTextFlags flags=0
 ):
     """Display multiline text input widget.
+
+    ``buffer_length`` is the maximum allowed length of the content.
 
     .. visual-example::
         :auto_layout:
@@ -3359,7 +3378,11 @@ def input_text_multiline(
 
         text_val = 'Type the your message here.'
         imgui.begin("Example: text input")
-        changed, text_val = imgui.input_text_multiline('Message:', text_val)
+        changed, text_val = imgui.input_text_multiline(
+            'Message:',
+            text_val,
+            2056
+        )
         imgui.text('You wrote:')
         imgui.same_line()
         imgui.text(text_val)
@@ -3368,6 +3391,7 @@ def input_text_multiline(
     Args:
         label (str): widget label.
         value (str): textbox value
+        buffer_length (int): length of the content buffer
         width (float): width of the textbox
         height (float): height of the textbox
         flags: InputText flags. See:
@@ -3388,17 +3412,20 @@ def input_text_multiline(
             void* user_data = NULL
         )
     """
-    cdef bytes bytes_text = _bytes(value)
-    cdef char inout_text[1024 * 16]
-    strcpy(inout_text, bytes_text)
+    value_bytes = _bytes(value)
+    value_len = len(value)
+
+    cdef char* inout_text = NULL
+    temp_value = value_bytes[:value_len]
+    inout_text = <bytes>temp_value
 
     changed = cimgui.InputTextMultiline(
-        _bytes(label), inout_text, sizeof(inout_text),
+        _bytes(label), inout_text, buffer_length,
         _cast_args_ImVec2(width, height), flags,
         NULL, NULL
     )
 
-    return changed, bytes_text.decode('utf-8')
+    return changed, _from_bytes(inout_text)
 
 
 def input_float(

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -3562,7 +3562,7 @@ def input_float3(
             ImGuiInputTextFlags extra_flags = 0
         )
     """
-    cdef float[3] inout_values = [value0, value1, values2]
+    cdef float[3] inout_values = [value0, value1, value2]
 
     return cimgui.InputFloat3(
         _bytes(label), <float*>&inout_values,
@@ -3607,7 +3607,7 @@ def input_float4(
             ImGuiInputTextFlags extra_flags = 0
         )
     """
-    cdef float[4] inout_values = [value0, value1, values2, value3]
+    cdef float[4] inout_values = [value0, value1, value2, value3]
 
     return cimgui.InputFloat4(
         _bytes(label), <float*>&inout_values,

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -22,6 +22,7 @@ except ImportError:
 from libc.stdlib cimport malloc, free
 from libc.stdint cimport uintptr_t
 from libc.string cimport strdup
+from libc.string cimport strcpy
 from libcpp cimport bool
 
 cimport cimgui

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -110,6 +110,25 @@ SELECTABLE_DONT_CLOSE_POPUPS = enums.ImGuiSelectableFlags_DontClosePopups
 SELECTABLE_SPAN_ALL_COLUMNS = enums.ImGuiSelectableFlags_SpanAllColumns
 SELECTABLE_ALLOW_DOUBLE_CLICK = enums.ImGuiSelectableFlags_AllowDoubleClick
 
+# ==== Text input flags ====
+INPUT_TEXT_CHARS_DECIMAL = enums.ImGuiInputTextFlags_CharsDecimal
+INPUT_TEXT_CHARS_HEXADECIMAL = enums.ImGuiInputTextFlags_CharsHexadecimal
+INPUT_TEXT_CHARS_UPPERCASE = enums.ImGuiInputTextFlags_CharsUppercase
+INPUT_TEXT_CHARS_NO_BLANK = enums.ImGuiInputTextFlags_CharsNoBlank
+INPUT_TEXT_AUTO_SELECT_ALL = enums.ImGuiInputTextFlags_AutoSelectAll
+INPUT_TEXT_ENTER_RETURNS_TRUE = enums.ImGuiInputTextFlags_EnterReturnsTrue
+INPUT_TEXT_CALLBACK_COMPLETION = enums.ImGuiInputTextFlags_CallbackCompletion
+INPUT_TEXT_CALLBACK_HISTORY = enums.ImGuiInputTextFlags_CallbackHistory
+INPUT_TEXT_CALLBACK_ALWAYS = enums.ImGuiInputTextFlags_CallbackAlways
+INPUT_TEXT_CALLBACK_CHAR_FILTER = enums.ImGuiInputTextFlags_CallbackCharFilter
+INPUT_TEXT_ALLOW_TAB_INPUT = enums.ImGuiInputTextFlags_AllowTabInput
+INPUT_TEXT_CTRL_ENTER_FOR_NEW_LINE = enums.ImGuiInputTextFlags_CtrlEnterForNewLine
+INPUT_TEXT_NO_HORIZONTAL_SCROLL = enums.ImGuiInputTextFlags_NoHorizontalScroll
+INPUT_TEXT_ALWAYS_INSERT_MODE = enums.ImGuiInputTextFlags_AlwaysInsertMode
+INPUT_TEXT_READ_ONLY = enums.ImGuiInputTextFlags_ReadOnly
+INPUT_TEXT_PASSWORD = enums.ImGuiInputTextFlags_Password
+
+
 Vec2 = namedtuple("Vec2", ['x', 'y'])
 Vec4 = namedtuple("Vec4", ['x', 'y', 'z', 'w'])
 
@@ -3271,6 +3290,475 @@ def drag_int4(
         label, <int*>&inout_values,
         change_speed, max_value, min_value, _bytes(display_format),
     ), (inout_values[0], inout_values[1], inout_values[2], inout_values[3])
+
+
+def input_text(str label, str value, cimgui.ImGuiInputTextFlags flags=0):
+    """Display text input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        text_val = 'Please, type the coefficient here.'
+        imgui.begin("Example: text input")
+        changed, text_val = imgui.input_text('Amount:', text_val)
+        imgui.text('You wrote:')
+        imgui.same_line()
+        imgui.text(text_val)
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value (str): textbox value
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, value)`` tuple that contains indicator of
+            textbox state change and the current text contents.
+
+    .. wraps::
+        bool InputText(
+            const char* label,
+            char* buf,
+            size_t buf_size,
+            ImGuiInputTextFlags flags = 0,
+            ImGuiTextEditCallback callback = NULL,
+            void* user_data = NULL
+        )
+    """
+
+    # return changed, bytes_text.decode('utf-8')
+
+    cdef bytes bytes_text = _bytes(value)
+    cdef char inout_text[2056]
+    strcpy(inout_text, bytes_text)
+
+    changed = cimgui.InputText(
+        _bytes(label), inout_text, sizeof(inout_text), flags, NULL, NULL
+    )
+
+    return changed, bytes_text.decode('utf-8')
+
+
+def input_text_multiline(
+    str label,
+    str value,
+    float width=0,
+    float height=0,
+    cimgui.ImGuiInputTextFlags flags=0
+):
+    """Display multiline text input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        text_val = 'Type the your message here.'
+        imgui.begin("Example: text input")
+        changed, text_val = imgui.input_text_multiline('Message:', text_val)
+        imgui.text('You wrote:')
+        imgui.same_line()
+        imgui.text(text_val)
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value (str): textbox value
+        width (float): width of the textbox
+        height (float): height of the textbox
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, value)`` tuple that contains indicator of
+            textbox state change and the current text contents.
+
+    .. wraps::
+        bool InputTextMultiline(
+            const char* label,
+            char* buf,
+            size_t buf_size,
+            const ImVec2& size = ImVec2(0,0),
+            ImGuiInputTextFlags flags = 0,
+            ImGuiTextEditCallback callback = NULL,
+            void* user_data = NULL
+        )
+    """
+    cdef bytes bytes_text = _bytes(value)
+    cdef char inout_text[1024 * 16]
+    strcpy(inout_text, bytes_text)
+
+    changed = cimgui.InputTextMultiline(
+        _bytes(label), inout_text, sizeof(inout_text),
+        _cast_args_ImVec2(width, height), flags,
+        NULL, NULL
+    )
+
+    return changed, bytes_text.decode('utf-8')
+
+
+def input_float(
+    str label,
+    float value,
+    float step=0.0,
+    float step_fast=0.0,
+    int decimal_precision=-1,
+    cimgui.ImGuiInputTextFlags flags=0
+):
+    """Display float input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        float_val = 0.4
+        imgui.begin("Example: float input")
+        changed, float_val = imgui.input_float('Type coefficient:', float_val)
+        imgui.text('You wrote: %f' % float_val)
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value (float): textbox value
+        step (float): incremental step
+        step_fast (float): fast incremental step
+        decimal_precision (int): float precision
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, value)`` tuple that contains indicator of
+            textbox state change and the current textbox content.
+
+    .. wraps::
+        bool InputFloat(
+            const char* label,
+            float* v,
+            float step = 0.0f,
+            float step_fast = 0.0f,
+            int decimal_precision = -1,
+            ImGuiInputTextFlags extra_flags = 0
+        )
+    """
+    cdef float inout_value = value
+
+    return cimgui.InputFloat(
+        _bytes(label), &inout_value, step,
+        step_fast, decimal_precision, flags
+    ), inout_value
+
+
+def input_float2(
+    str label,
+    float value0, float value1,
+    int decimal_precision=-1,
+    cimgui.ImGuiInputTextFlags flags=0
+):
+    """Display two-float input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        values = 0.4, 3.2
+        imgui.begin("Example: two float inputs")
+        changed, values = imgui.input_float2('Type here:', *values)
+        imgui.text("Changed: %s, Values: %s" % (changed, values))
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value0, value1 (float): input values.
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, values)`` tuple that contains indicator of
+            textbox state change and the tuple of current values.
+
+    .. wraps::
+        bool InputFloat2(
+            const char* label,
+            float v[2],
+            int decimal_precision = -1,
+            ImGuiInputTextFlags extra_flags = 0
+        )
+    """
+    cdef float[2] inout_values = [value0, value1]
+
+    return cimgui.InputFloat2(
+        _bytes(label), <float*>&inout_values,
+        decimal_precision, flags
+    ), (inout_values[0], inout_values[1])
+
+
+def input_float3(
+    str label,
+    float value0, float value1, float value2,
+    int decimal_precision=-1,
+    cimgui.ImGuiInputTextFlags flags=0
+):
+    """Display three-float input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        values = 0.4, 3.2, 29.3
+        imgui.begin("Example: three float inputs")
+        changed, values = imgui.input_float3('Type here:', *values)
+        imgui.text("Changed: %s, Values: %s" % (changed, values))
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value0, value1, value2 (float): input values.
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, values)`` tuple that contains indicator of
+            textbox state change and the tuple of current values.
+
+    .. wraps::
+        bool InputFloat3(
+            const char* label,
+            float v[3],
+            int decimal_precision = -1,
+            ImGuiInputTextFlags extra_flags = 0
+        )
+    """
+    cdef float[3] inout_values = [value0, value1, values2]
+
+    return cimgui.InputFloat3(
+        _bytes(label), <float*>&inout_values,
+        decimal_precision, flags
+    ), (inout_values[0], inout_values[1], inout_values[2])
+
+
+def input_float4(
+    str label,
+    float value0, float value1, float value2, float value3,
+    int decimal_precision=-1,
+    cimgui.ImGuiInputTextFlags flags=0
+):
+    """Display four-float input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        values = 0.4, 3.2, 29.3, 12.9
+        imgui.begin("Example: four float inputs")
+        changed, values = imgui.input_float4('Type here:', *values)
+        imgui.text("Changed: %s, Values: %s" % (changed, values))
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value0, value1, value2, value3 (float): input values.
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, values)`` tuple that contains indicator of
+            textbox state change and the tuple of current values.
+
+    .. wraps::
+        bool InputFloat4(
+            const char* label,
+            float v[4],
+            int decimal_precision = -1,
+            ImGuiInputTextFlags extra_flags = 0
+        )
+    """
+    cdef float[4] inout_values = [value0, value1, values2, value3]
+
+    return cimgui.InputFloat4(
+        _bytes(label), <float*>&inout_values,
+        decimal_precision, flags
+    ), (inout_values[0], inout_values[1], inout_values[2], inout_values[3])
+
+
+def input_int(
+    str label,
+    int value,
+    int step=1,
+    int step_fast=100,
+    cimgui.ImGuiInputTextFlags flags=0
+):
+    """Display integer input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        int_val = 3
+        imgui.begin("Example: integer input")
+        changed, int_val = imgui.input_float('Type multiplier:', int_val)
+        imgui.text('You wrote: %i' % int_val)
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value (int): textbox value
+        step (int): incremental step
+        step_fast (int): fast incremental step
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, value)`` tuple that contains indicator of
+            textbox state change and the current textbox content.
+
+    .. wraps::
+        bool InputInt(
+            const char* label,
+            int* v,
+            int step = 1,
+            int step_fast = 100,
+            ImGuiInputTextFlags extra_flags = 0
+        )
+    """
+    cdef int inout_value = value
+
+    return cimgui.InputInt(
+        _bytes(label), &inout_value, step, step_fast, flags
+    ), inout_value
+
+
+def input_int2(
+    str label,
+    int value0, int value1,
+    cimgui.ImGuiInputTextFlags flags=0
+):
+    """Display two-integer input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        values = 4, 12
+        imgui.begin("Example: two int inputs")
+        changed, values = imgui.input_int2('Type here:', *values)
+        imgui.text("Changed: %s, Values: %s" % (changed, values))
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value0, value1 (int): textbox values
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, value)`` tuple that contains indicator of
+            textbox state change and the current textbox content.
+
+    .. wraps::
+        bool InputInt2(
+            const char* label,
+            int v[2],
+            ImGuiInputTextFlags extra_flags = 0
+        )
+    """
+    cdef int[2] inout_values = [value0, value1]
+
+    return cimgui.InputInt2(
+        _bytes(label), <int*>&inout_values, flags
+    ), [inout_values[0], inout_values[1]]
+
+
+def input_int3(
+    str label,
+    int value0, int value1, int value2,
+    cimgui.ImGuiInputTextFlags flags=0
+):
+    """Display three-integer input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        values = 4, 12, 28
+        imgui.begin("Example: three int inputs")
+        changed, values = imgui.input_int3('Type here:', *values)
+        imgui.text("Changed: %s, Values: %s" % (changed, values))
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value0, value1, value2 (int): textbox values
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, value)`` tuple that contains indicator of
+            textbox state change and the current textbox content.
+
+    .. wraps::
+        bool InputInt3(
+            const char* label,
+            int v[3],
+            ImGuiInputTextFlags extra_flags = 0
+        )
+    """
+    cdef int[3] inout_values = [value0, value1, value2]
+
+    return cimgui.InputInt3(
+        _bytes(label), <int*>&inout_values, flags
+    ), [inout_values[0], inout_values[1], inout_values[2]]
+
+
+def input_int4(
+    str label,
+    int value0, int value1, int value2, int value3,
+    cimgui.ImGuiInputTextFlags flags=0
+):
+    """Display four-integer input widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 200
+        :height: 100
+
+        values = 4, 12, 28, 73
+        imgui.begin("Example: four int inputs")
+        changed, values = imgui.input_int4('Type here:', *values)
+        imgui.text("Changed: %s, Values: %s" % (changed, values))
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value0, value1, value2, value3 (int): textbox values
+        flags: InputText flags. See:
+            :ref:`list of available flags <inputtext-flag-options>`.
+
+    Returns:
+        tuple: a ``(changed, value)`` tuple that contains indicator of
+            textbox state change and the current textbox content.
+
+    .. wraps::
+        bool InputInt4(
+            const char* label,
+            int v[4],
+            ImGuiInputTextFlags extra_flags = 0
+        )
+    """
+    cdef int[4] inout_values = [value0, value1, value2, value3]
+
+    return cimgui.InputInt4(
+        _bytes(label), <int*>&inout_values, flags
+    ), [inout_values[0], inout_values[1], inout_values[2], inout_values[3]]
 
 
 def slider_float(

--- a/imgui/enums.pxd
+++ b/imgui/enums.pxd
@@ -124,3 +124,21 @@ cdef extern from "imgui.h":
         ImGuiSelectableFlags_DontClosePopups    # Clicking this don't close parent popup window
         ImGuiSelectableFlags_SpanAllColumns     # Selectable frame can span all columns (text will still fit in current column)
         ImGuiSelectableFlags_AllowDoubleClick   # Generate press events on double clicks too
+
+    ctypedef enum ImGuiInputTextFlags_:
+        ImGuiInputTextFlags_CharsDecimal        # Allow 0123456789.+-*/
+        ImGuiInputTextFlags_CharsHexadecimal    # Allow 0123456789ABCDEFabcdef
+        ImGuiInputTextFlags_CharsUppercase      # Turn a..z into A..Z
+        ImGuiInputTextFlags_CharsNoBlank        # Filter out spaces, tabs
+        ImGuiInputTextFlags_AutoSelectAll       # Select entire text when first taking mouse focus
+        ImGuiInputTextFlags_EnterReturnsTrue    # Return 'true' when Enter is pressed (as opposed to when the value was modified)
+        ImGuiInputTextFlags_CallbackCompletion  # Call user function on pressing TAB (for completion handling)
+        ImGuiInputTextFlags_CallbackHistory     # Call user function on pressing Up/Down arrows (for history handling)
+        ImGuiInputTextFlags_CallbackAlways      # Call user function every time. User code may query cursor position, modify text buffer.
+        ImGuiInputTextFlags_CallbackCharFilter  # Call user function to filter character. Modify data->EventChar to replace/filter input, or return 1 to discard character.
+        ImGuiInputTextFlags_AllowTabInput       # Pressing TAB input a '\t' character into the text field
+        ImGuiInputTextFlags_CtrlEnterForNewLine # In multi-line mode, allow exiting edition by pressing Enter. Ctrl+Enter to add new line (by default adds new lines with Enter).
+        ImGuiInputTextFlags_NoHorizontalScroll  # Disable following the cursor horizontally
+        ImGuiInputTextFlags_AlwaysInsertMode    # Insert mode
+        ImGuiInputTextFlags_ReadOnly            # Read-only mode
+        ImGuiInputTextFlags_Password            # Password mode, display all characters as '*'


### PR DESCRIPTION
Hey :),

This one contains the InputXYZ functions. There's one not-so-minor issue, which also is present in the ImGui demo window.
For InputText if the buffer size is not specified as something big like 1024 or bigger it will take the passed value and use it as a limit - so if you pass "Text" it will display text but will also put limit of 4 chars on the input. No idea why this happens, so i've put a 2056 char array as limit for now. Same applies for the InputTextMultiline function.
Another issue with the inputs i noticed is that it works too fast, meaning if i type "A" it's ok, but if i do backspace (delete) and enter (new lines) it deletes multiple characters/words or puts lots of new lines. Same behaviour exists in the ImGui demo window by the way, so i think it might be something either in the implementation or in Cython itself.

Will keep digging to see if i can fix it.

P.S. Same type of issues i noticed with scrolling - if you have a big height window and you scroll with the mouse for ex., it always goes either at the top or at the bottom, you can't position it in the middle. Same issues with the combo lists. 

P.P.S. All of those are observed on Python 3.5 with the PySDL implementation, so they might not be present in Python 2.X.

Cheers,
S.