### PR TITLE
Allow to create working self-contained sdist packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,16 @@
+include README.md
+include LICENSE
+
+# Cython sources
+recursive-include imgui *.pyx *.pxd
+
+# Cython-generated C++ sources
+recursive-include imgui *.cpp *.h
+
+# Additional internal ImgGui configuration
+recursive-include config-cpp *.cpp *.h
+
+# ImGui sources
+recursive-include imgui-cpp *.cpp *.h
+prune imgui-cpp/examples
+prune imgui-cpp/extra_fonts

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,9 @@ completion:
 	_CYTHONIZE_WITH_COVERAGE=1 python -m pip install -e . -v
 	@python ci/completion.py missing `find build/ -name imgui.o -print -quit` `find build/ -name core.o -print -quit`
 	@python ci/completion.py with-nm `find build/ -name imgui.o -print -quit` `find build/ -name core.o -print -quit`
+
+.PHONY: ditribute
+distribute:
+	pip install -U Cython
+	python setup.py build
+	python sdist

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ completion:
 	@python ci/completion.py with-nm `find build/ -name imgui.o -print -quit` `find build/ -name core.o -print -quit`
 
 .PHONY: ditribute
-distribute:
-	pip install -U Cython
+distribute: clean
+	pip install -U Cython setuptools twine
 	python setup.py build
-	python sdist
+	python setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -118,8 +118,6 @@ setup(
     long_description=read_md(README),
     url="https://github.com/swistakm/pyimgui",
 
-    install_requires=['cython'],
-    setup_requires=['cython'],
     ext_modules=cythonize(
         EXTENSIONS,
         compiler_directives=compiler_directives, **cythonize_opts


### PR DESCRIPTION
Added option to create *sdist* packages:
* Include both Cython sources and plain Cython-generated C++ sources in *sdist* archives with proper `MANIFEST.in` template,
* Add option to install `imgui` with Cython compilation using `extras_require`:

      pip install imgui[Cython]

  With this extras option `Cython` package will be included as requirements. If it is available during `imgui` sdist package instalation then `setuptools` will compile Cython sources (`.pyx`, `.pxd` files) to C++ sources and only then perform final compilation. 

* Add helper makefile target that will be used during actual code distribution on PyPI,

This change has small caveat: it will work as intended (Cython will be used with extras uption during sdist installation) only if user does not have `wheel` package installed. Still, this shouldn't be an issue because:
* Our main goal is to ship fully working wheels and not sdists. The sdists distributions are just a fallback mechanism for certain some OS/environments where our wheels may not work properly.
* The users of `wheel` package will in most cases download wheels without knowing that there is sdist distribution
* The sdist distribution includes generated C++ sources too so the final compilation is possible even without Cython installed.