### PR TITLE
Upgrade to imgui 1.51

### DIFF
--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -890,9 +890,9 @@ cdef extern from "imgui.h" namespace "ImGui":
             int mouse_button
     ) except +
     bool BeginPopupContextWindow(  # ✓
-            bool also_over_items, const char* str_id,
+            const char* str_id,
             # note: optional
-            int mouse_button
+            int mouse_button, bool also_over_items
     ) except +
     bool BeginPopupContextVoid(  # ✓
             # note: optional

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -989,7 +989,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     ) except +
     bool IsMouseDoubleClicked(int button) except +  # ✓
     bool IsMouseReleased(int button) except +  # ✗
-    bool IsMouseHoveringWindow() except +  # ✓
+    bool IsWindowRectHovered() except +  # ✓
     bool IsAnyWindowHovered() except +  # ✓
     bool IsMouseHoveringRect(  # ✓
             const ImVec2& r_min, const ImVec2& r_max,

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -990,7 +990,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     bool IsMouseDoubleClicked(int button) except +  # ✓
     bool IsMouseReleased(int button) except +  # ✗
     bool IsMouseHoveringWindow() except +  # ✓
-    bool IsMouseHoveringAnyWindow() except +  # ✓
+    bool IsAnyWindowHovered() except +  # ✓
     bool IsMouseHoveringRect(  # ✓
             const ImVec2& r_min, const ImVec2& r_max,
             # note: optional

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -397,6 +397,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     void PushFont(ImFont*) except +  # ✓
     void PopFont() except +  # ✓
     void PushStyleColor(ImGuiCol, const ImVec4&) except +  # ✓
+    # void PushStyleColor(ImGuiCol idx, ImU32 col) # ✗
     void PopStyleColor(int) except +  # ✓
     void PushStyleVar(ImGuiStyleVar, float) except +  # ✓
     void PushStyleVar(ImGuiStyleVar, const ImVec2&) except +  # ✓

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -47,7 +47,7 @@ cdef extern from "imgui.h":
     ctypedef int ImGuiColorEditMode
     ctypedef int ImGuiMouseCursor
     ctypedef int ImGuiWindowFlags
-    ctypedef int ImGuiSetCond
+    ctypedef int ImGuiCond
     ctypedef int ImGuiInputTextFlags
     ctypedef int ImGuiSelectableFlags
     ctypedef int ImGuiTreeNodeFlags
@@ -313,16 +313,16 @@ cdef extern from "imgui.h" namespace "ImGui":
     void SetNextWindowPos(  # ✓ note: overrides ommited
             const ImVec2& pos,
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     void SetNextWindowPosCenter(  # ✓ note: overrides ommited
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     void SetNextWindowSize(  # ✓ note: overrides ommited
             const ImVec2& size,
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     void SetNextWindowSizeConstraints(  # ✗
             const ImVec2& size_min,
@@ -335,38 +335,38 @@ cdef extern from "imgui.h" namespace "ImGui":
     void SetNextWindowCollapsed(  # ✓
             bool collapsed,
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     void SetNextWindowFocus() except +  # ✓
     void SetWindowPos(  # ✗
             const ImVec2& pos,
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     void SetWindowSize(  # ✗
             const ImVec2& size,
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     void SetWindowCollapsed(  # ✗
             bool collapsed,
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     void SetWindowFocus() except +  # ✗
     void SetWindowPos(  # ✗
             const char* name, const ImVec2& pos,
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     void SetWindowSize(  # ✗
-            const char* name, const ImVec2& size, ImGuiSetCond
+            const char* name, const ImVec2& size, ImGuiCond
             cond
     ) except +
     void SetWindowCollapsed(  # ✗
             const char* name, bool collapsed,
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     void SetWindowFocus(const char* name) except +  # ✗
 
@@ -789,7 +789,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     void SetNextTreeNodeOpen(  # ✗
             bool is_open,
             # note: optional
-            ImGuiSetCond cond
+            ImGuiCond cond
     ) except +
     bool CollapsingHeader(  # ✓
             const char* label,

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -508,12 +508,13 @@ cdef extern from "imgui.h" namespace "ImGui":
             const ImVec2& uv0, const ImVec2& uv1, int frame_padding,
             const ImVec4& bg_col, const ImVec4& tint_col
     ) except +
-    
-    bool ColorButton(  # ✓
-            const ImVec4& col,
-            # note: optional
-            bool small_height, bool outline_border
-    ) except +  # Widgets: images
+    bool ColorButton( # ✓
+        const char*, ImVec4 col,
+        # note: optional
+        ImGuiColorEditFlags flags, ImVec2 size
+    ) except +
+
+    # Widgets: images
     void Image(  # ✓
             ImTextureID user_texture_id, const ImVec2& size,
             # note: optional

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -945,7 +945,6 @@ cdef extern from "imgui.h" namespace "ImGui":
     bool IsRootWindowOrAnyChildFocused() except +  # ✓
     bool IsRootWindowOrAnyChildHovered() except +  # ✓
     bool IsRectVisible(const ImVec2& size) except +  # ✓
-    bool IsPosHoveringAnyWindow(const ImVec2& pos) except +  # ✓
     float GetTime() except +  # ✗
     int GetFrameCount() except +  # ✗
     const char* GetStyleColName(ImGuiCol idx) except +  # ✗

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -44,7 +44,7 @@ cdef extern from "imgui.h":
     ctypedef int ImGuiStyleVar
     ctypedef int ImGuiKey
     ctypedef int ImGuiAlign
-    ctypedef int ImGuiColorEditMode
+    ctypedef int ImGuiColorEditFlags
     ctypedef int ImGuiMouseCursor
     ctypedef int ImGuiWindowFlags
     ctypedef int ImGuiCond
@@ -553,7 +553,7 @@ cdef extern from "imgui.h" namespace "ImGui":
             const char* label, float col[4],
             # note: optional
             bool show_alpha
-    ) except +  #void ColorEditMode(ImGuiColorEditMode mode) except +  # note: obsoleted
+    ) except +
 
     # Widgets: plots
     void PlotLines(  # ✗

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -946,7 +946,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     bool IsRectVisible(const ImVec2& size) except +  # ✓
     float GetTime() except +  # ✗
     int GetFrameCount() except +  # ✗
-    const char* GetStyleColName(ImGuiCol idx) except +  # ✗
+    const char* GetStyleColorName(ImGuiCol idx) except +  # ✗
     ImVec2 CalcItemRectClosestPoint(  # ✗
             const ImVec2& pos,
             # note: optional

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -553,7 +553,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     bool ColorEdit4(  # ✓
             const char* label, float col[4],
             # note: optional
-            bool show_alpha
+            ImGuiColorEditFlags flags
     ) except +
 
     # Widgets: plots

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -846,8 +846,6 @@ cdef extern from "imgui.h" namespace "ImGui":
             # note: optional
             const char* float_format
     ) except +
-    void ValueColor(const char* prefix, const ImVec4& v) except +  # ✗
-    void ValueColor(const char* prefix, unsigned int v) except +  # ✗
 
     # Tooltips
     void SetTooltip(const char* fmt, ...) except +  # ✓

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -924,7 +924,7 @@ cdef extern from "imgui.h" namespace "ImGui":
 
     # Utilities
     bool IsItemHovered() except +  # ✓
-    bool IsItemHoveredRect() except +  # ✓
+    bool IsItemRectHovered() except +  # ✓
     bool IsItemActive() except +  # ✓
     bool IsItemClicked(  # ✓
             # note: optional

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -36,10 +36,10 @@ DEF TARGET_IMGUI_VERSION = (1, 49)
 cdef unsigned short* _LATIN_ALL = [0x0020, 0x024F , 0]
 
 # ==== Condition enum redefines ====
-ALWAYS = enums.ImGuiSetCond_Always
-ONCE = enums.ImGuiSetCond_Once
-FIRST_USE_EVER = enums.ImGuiSetCond_FirstUseEver
-APPEARING = enums.ImGuiSetCond_Appearing
+ALWAYS = enums.ImGuiCond_Always
+ONCE = enums.ImGuiCond_Once
+FIRST_USE_EVER = enums.ImGuiCond_FirstUseEver
+APPEARING = enums.ImGuiCond_Appearing
 
 # ==== Style var enum redefines ====
 STYLE_ALPHA = enums.ImGuiStyleVar_Alpha # float
@@ -1354,7 +1354,7 @@ def set_window_font_scale(float scale):
 
 
 def set_next_window_collapsed(
-    cimgui.bool collapsed, cimgui.ImGuiSetCond condition=ALWAYS
+    cimgui.bool collapsed, cimgui.ImGuiCond condition=ALWAYS
 ):
     """Set next window collapsed state.
 
@@ -1376,7 +1376,7 @@ def set_next_window_collapsed(
 
     .. wraps::
          void SetNextWindowCollapsed(
-             bool collapsed, ImGuiSetCond cond = 0
+             bool collapsed, ImGuiCond cond = 0
          )
 
     """
@@ -1444,7 +1444,7 @@ def get_window_height():
 
 
 def set_next_window_position(
-    float x, float y, cimgui.ImGuiSetCond condition=ALWAYS
+    float x, float y, cimgui.ImGuiCond condition=ALWAYS
 ):
     """Set next window position.
 
@@ -1468,13 +1468,13 @@ def set_next_window_position(
             imgui.end()
 
     .. wraps::
-        void SetNextWindowPos(const ImVec2& pos, ImGuiSetCond cond = 0)
+        void SetNextWindowPos(const ImVec2& pos, ImGuiCond cond = 0)
 
     """
     cimgui.SetNextWindowPos(_cast_args_ImVec2(x, y), condition)
 
 
-def set_next_window_centered(cimgui.ImGuiSetCond condition=ALWAYS):
+def set_next_window_centered(cimgui.ImGuiCond condition=ALWAYS):
     """Set next window position to be centered on screen.
 
     Call before :func:`begin()`.
@@ -1495,13 +1495,13 @@ def set_next_window_centered(cimgui.ImGuiSetCond condition=ALWAYS):
 
 
     .. wraps::
-        void SetNextWindowPosCenter(ImGuiSetCond cond = 0)
+        void SetNextWindowPosCenter(ImGuiCond cond = 0)
     """
     cimgui.SetNextWindowPosCenter(condition)
 
 
 def set_next_window_size(
-    float width, float height, cimgui.ImGuiSetCond condition=ALWAYS
+    float width, float height, cimgui.ImGuiCond condition=ALWAYS
 ):
     """Set next window size.
 
@@ -1525,7 +1525,7 @@ def set_next_window_size(
 
     .. wraps::
         void SetNextWindowSize(
-            const ImVec2& size, ImGuiSetCond cond = 0
+            const ImVec2& size, ImGuiCond cond = 0
         )
     """
     cimgui.SetNextWindowSize(_cast_args_ImVec2(width, height), condition)

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -4381,7 +4381,7 @@ def is_item_hovered():
     return cimgui.IsItemHovered()
 
 
-def is_item_hovered_rect():
+def is_item_rect_hovered():
     """Was the last item hovered by mouse? Even if
     another item is active or window is blocked by popup
     while we are hovering this.
@@ -4390,9 +4390,9 @@ def is_item_hovered_rect():
         bool: True if item is hovered by mouse, otherwise False.
 
     .. wraps::
-        bool IsItemHoveredRect()
+        bool IsItemRectHovered()
     """
-    return cimgui.IsItemHoveredRect()
+    return cimgui.IsItemRectHovered()
 
 
 def is_item_active():

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -4584,16 +4584,16 @@ def is_rect_visible(float size_width, float size_height):
     return cimgui.IsRectVisible(_cast_args_ImVec2(size_width, size_height))
 
 
-def is_mouse_hovering_window():
+def is_window_rect_hovered():
     """Test if mouse is hovering the current window.
 
     Returns:
         bool: True if the window is hovered, otherwise False.
 
     .. wraps::
-        bool IsMouseHoveringWindow()
+        bool IsWindowRectHovered()
     """
-    return cimgui.IsMouseHoveringWindow()
+    return cimgui.IsWindowRectHovered()
 
 
 def is_any_window_hovered():

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -2590,11 +2590,12 @@ def invisible_button(str identifier, width, height):
         _cast_args_ImVec2(width, height)
     )
 
-
 def color_button(
+        desc_id,
         float r, float g, float b, a=1.,
-        cimgui.bool small_height=False,
-        cimgui.bool outline_border=True,
+        cimgui.ImGuiColorEditFlags flags = 0,
+        float width= 0.,
+        float height=0.,
 ):
     """Display colored button.
 
@@ -2603,10 +2604,10 @@ def color_button(
         :height: 150
 
         imgui.begin("Example: color button")
-        imgui.color_button(1, 0, 0, 1, True, True)
-        imgui.color_button(0, 1, 0, 1, True, False)
-        imgui.color_button(0, 0, 1, 1, False, True)
-        imgui.color_button(1, 0, 1, 1, False, False)
+        imgui.color_button('Red', 1, 0, 0, 1)
+        imgui.color_button('Green', 0, 1, 0, 1)
+        imgui.color_button('Blue', 0, 0, 1, 1)
+        imgui.color_button('Violet', 1, 0, 1, 1)
         imgui.end()
 
     Args:
@@ -2614,23 +2615,28 @@ def color_button(
         g (float): green color intensity.
         b (float): blue color instensity.
         a (float): alpha intensity.
-        small_height (bool): Small height. Default to False
-        outline_border (bool): Diplay outline border. Defaults to True.
+        # note: optionals below
+        cimgui.ImGuiColorEditFlags flags,
+        float width,
+        float height,
 
     Returns:
         bool: True if button is clicked.
 
     .. wraps::
         bool ColorButton(
-            const ImVec4& col,
-            bool small_height = false,
-            bool outline_border = true
+            const char* desc_id,
+            ImVec4& col,
+            # note: optional
+            ImGuiColorEditFlags flags, ImVec2 size
         )
     """
     return cimgui.ColorButton(
-        _cast_args_ImVec4(r, g, b, a), small_height, outline_border
+        "%s" % _bytes(desc_id),
+        _cast_args_ImVec4(r, g, b, a),
+        flags,
+        _cast_args_ImVec2(width, height),
     )
-
 
 def image_button(
     texture_id,

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -4584,24 +4584,6 @@ def is_rect_visible(float size_width, float size_height):
     return cimgui.IsRectVisible(_cast_args_ImVec2(size_width, size_height))
 
 
-def is_pos_hovering_any_window(float position_x, float position_y):
-    """Test if position is hovering any active ImGui window.
-
-    Args:
-        position_x (float): width of the rect
-        position_y (float): height of the rect
-
-    Returns:
-        bool: True if rect is visible, otherwise False.
-
-    .. wraps::
-        bool IsPosHoveringAnyWindow(const ImVec2& size)
-    """
-    return cimgui.IsPosHoveringAnyWindow(
-        _cast_args_ImVec2(position_x, position_y)
-    )
-
-
 def is_mouse_hovering_window():
     """Test if mouse is hovering the current window.
 

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -114,6 +114,27 @@ SELECTABLE_DONT_CLOSE_POPUPS = enums.ImGuiSelectableFlags_DontClosePopups
 SELECTABLE_SPAN_ALL_COLUMNS = enums.ImGuiSelectableFlags_SpanAllColumns
 SELECTABLE_ALLOW_DOUBLE_CLICK = enums.ImGuiSelectableFlags_AllowDoubleClick
 
+# ==== ColorEdit flags enum redefines ====
+COLOR_EDIT_NO_ALPHA = enums.ImGuiColorEditFlags_NoAlpha
+COLOR_EDIT_NO_PICKER = enums.ImGuiColorEditFlags_NoPicker
+COLOR_EDIT_NO_OPTIONS = enums.ImGuiColorEditFlags_NoOptions
+COLOR_EDIT_NO_SMALL_PREVIEW = enums.ImGuiColorEditFlags_NoSmallPreview
+COLOR_EDIT_NO_INPUTS = enums.ImGuiColorEditFlags_NoInputs
+COLOR_EDIT_NO_TOOLTIP = enums.ImGuiColorEditFlags_NoTooltip
+COLOR_EDIT_NO_LABEL = enums.ImGuiColorEditFlags_NoLabel
+COLOR_EDIT_NO_SIDE_PREVIEW = enums.ImGuiColorEditFlags_NoSidePreview
+COLOR_EDIT_ALPHA_BAR = enums.ImGuiColorEditFlags_AlphaBar
+COLOR_EDIT_ALPHA_PREVIEW = enums.ImGuiColorEditFlags_AlphaPreview
+COLOR_EDIT_ALPHA_PREVIEW_HALF = enums.ImGuiColorEditFlags_AlphaPreviewHalf
+COLOR_EDIT_HDR = enums.ImGuiColorEditFlags_HDR
+COLOR_EDIT_RGB = enums.ImGuiColorEditFlags_RGB
+COLOR_EDIT_HSV = enums.ImGuiColorEditFlags_HSV
+COLOR_EDIT_HEX = enums.ImGuiColorEditFlags_HEX
+COLOR_EDIT_UINT8 = enums.ImGuiColorEditFlags_Uint8
+COLOR_EDIT_FLOAT = enums.ImGuiColorEditFlags_Float
+COLOR_EDIT_PICKER_HUE_BAR = enums.ImGuiColorEditFlags_PickerHueBar
+COLOR_EDIT_PICKER_HUE_WHEEL = enums.ImGuiColorEditFlags_PickerHueWheel
+
 # ==== Mouse Cursors ====
 MOUSE_CURSOR_ARROW = enums.ImGuiMouseCursor_Arrow
 MOUSE_CURSOR_TEXT_INPUT = enums.ImGuiMouseCursor_TextInput
@@ -2921,7 +2942,7 @@ def color_edit3(str label, float r, float g, float b):
 
 
 def color_edit4(
-    str label, float r, float g, float b, float a, cimgui.bool show_alpha=True
+    str label, float r, float g, float b, float a, unsigned int flags=0
 ):
     """Display color edit widget for color with alpha value.
 
@@ -2930,11 +2951,12 @@ def color_edit4(
         :width: 400
 
         color = 1., .0, .5, 1.
+        flags = imgui.COLOR_EDIT_NO_ALPHA
 
         imgui.begin("Example: color edit with alpha")
 
-        _, color = imgui.color_edit4("Alpha", *color, show_alpha=True)
-        _, color = imgui.color_edit4("No alpha", *color, show_alpha=False)
+        _, color = imgui.color_edit4("Alpha", *color, flags=flags)
+        _, color = imgui.color_edit4("No alpha", *color, flags=0)
 
         imgui.end()
 
@@ -2944,7 +2966,7 @@ def color_edit4(
         g (float): green color intensity.
         b (float): blue color instensity.
         a (float): alpha intensity.
-        show_alpha (bool): if set to True wiget allows to modify alpha
+        flags (ImGuiColorEditFlags): Flags for the ColorEdit widget.
 
     Returns:
         tuple: a ``(changed, color)`` tuple that contains indicator of color
@@ -2952,13 +2974,13 @@ def color_edit4(
 
     .. wraps::
         ColorEdit4(
-            const char* label, float col[4], bool show_alpha = true
+            const char* label, float col[4], ImGuiColorEditFlags flags = 0
         )
     """
     cdef float[4] inout_color = [r, g, b, a]
 
     return cimgui.ColorEdit4(
-        _bytes(label), <float *>(&inout_color), show_alpha
+        _bytes(label), <float *>(&inout_color), flags
     ), (inout_color[0], inout_color[1], inout_color[2], inout_color[3])
 
 

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -4596,16 +4596,16 @@ def is_mouse_hovering_window():
     return cimgui.IsMouseHoveringWindow()
 
 
-def is_mouse_hovering_any_window():
+def is_any_window_hovered():
     """Test if mouse is hovering any visible window.
 
     Returns:
         bool: True if any item is hovered, otherwise False.
 
     .. wraps::
-        bool IsMouseHoveringAnyWindow()
+        bool IsAnyWindowHovered()
     """
-    return cimgui.IsMouseHoveringAnyWindow()
+    return cimgui.IsAnyWindowHovered()
 
 
 def is_mouse_hovering_rect(

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -2252,9 +2252,9 @@ def begin_popup_context_item(str name, int mouse_button=1):
 
 
 def begin_popup_context_window(
-    bool also_over_items=True,
     str name=None,
-    int mouse_button=1
+    int mouse_button=1,
+    bool also_over_items=True
 ):
     """Helper function to open and begin popup when clicked on current window.
 
@@ -2286,22 +2286,22 @@ def begin_popup_context_window(
 
     .. wraps::
         bool BeginPopupContextWindow(
-            bool also_over_items = true,
             const char* str_id = NULL,
             int mouse_button = 1
+            bool also_over_items = true,
         )
     """
     if name is None:
         return cimgui.BeginPopupContextWindow(
-            also_over_items,
             NULL,
-            mouse_button
+            mouse_button,
+            also_over_items
         )
     else:
         return cimgui.BeginPopupContextWindow(
-            also_over_items,
             _bytes(name),
-            mouse_button
+            mouse_button,
+            also_over_items
         )
 
 

--- a/imgui/enums.pxd
+++ b/imgui/enums.pxd
@@ -134,6 +134,36 @@ cdef extern from "imgui.h":
         ImGuiSelectableFlags_SpanAllColumns     # Selectable frame can span all columns (text will still fit in current column)
         ImGuiSelectableFlags_AllowDoubleClick   # Generate press events on double clicks too
 
+    # Enumeration for ColorEdit3() / ColorEdit4() / ColorPicker3() / ColorPicker4() / ColorButton()
+    ctypedef enum ImGuiColorEditFlags_:
+        ImGuiColorEditFlags_NoAlpha            #              # ColorEdit, ColorPicker, ColorButton: ignore Alpha component (read 3 components from the input pointer).
+        ImGuiColorEditFlags_NoPicker           #              # ColorEdit: disable picker when clicking on colored square.
+        ImGuiColorEditFlags_NoOptions          #              # ColorEdit: disable toggling options menu when right-clicking on inputs/small preview.
+        ImGuiColorEditFlags_NoSmallPreview     #              # ColorEdit, ColorPicker: disable colored square preview next to the inputs. (e.g. to show only the inputs)
+        ImGuiColorEditFlags_NoInputs           #              # ColorEdit, ColorPicker: disable inputs sliders/text widgets (e.g. to show only the small preview colored square).
+        ImGuiColorEditFlags_NoTooltip          #              # ColorEdit, ColorPicker, ColorButton: disable tooltip when hovering the preview.
+        ImGuiColorEditFlags_NoLabel            #              # ColorEdit, ColorPicker: disable display of inline text label (the label is still forwarded to the tooltip and picker).
+        ImGuiColorEditFlags_NoSidePreview      #              # ColorPicker: disable bigger color preview on right side of the picker, use small colored square preview instead.
+        # User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions(). The idea is that you probably don't want to override them in most of your calls, let the user choose and/or call SetColorEditOptions() during startup.
+        ImGuiColorEditFlags_AlphaBar           #              # ColorEdit, ColorPicker: show vertical alpha bar/gradient in picker.
+        ImGuiColorEditFlags_AlphaPreview      #              # ColorEdit, ColorPicker, ColorButton: display preview as a transparent color over a checkerboard, instead of opaque.
+        ImGuiColorEditFlags_AlphaPreviewHalf  #              # ColorEdit, ColorPicker, ColorButton: display half opaque / half checkerboard, instead of opaque.
+        ImGuiColorEditFlags_HDR               #              # (WIP) ColorEdit: Currently only disable 0.0f..1.0f limits in RGBA edition (note: you probably want to use ImGuiColorEditFlags_Float flag as well).
+        ImGuiColorEditFlags_RGB               # [Inputs]     # ColorEdit: choose one among RGB/HSV/HEX. ColorPicker: choose any combination using RGB/HSV/HEX.
+        ImGuiColorEditFlags_HSV               # [Inputs]     # "
+        ImGuiColorEditFlags_HEX               # [Inputs]     # "
+        ImGuiColorEditFlags_Uint8             # [DataType]   # ColorEdit, ColorPicker, ColorButton: _display_ values formatted as 0..255.
+        ImGuiColorEditFlags_Float             # [DataType]   # ColorEdit, ColorPicker, ColorButton: _display_ values formatted as 0.0f..1.0f floats instead of 0..255 integers. No round-trip of value via integers.
+        ImGuiColorEditFlags_PickerHueBar      # [PickerMode] # ColorPicker: bar for Hue, rectangle for Sat/Value.
+        ImGuiColorEditFlags_PickerHueWheel    # [PickerMode] # ColorPicker: wheel for Hue, triangle for Sat/Value.
+
+        # // Internals/Masks
+        # ImGuiColorEditFlags__InputsMask     = ImGuiColorEditFlags_RGB|ImGuiColorEditFlags_HSV|ImGuiColorEditFlags_HEX,
+        # ImGuiColorEditFlags__DataTypeMask   = ImGuiColorEditFlags_Uint8|ImGuiColorEditFlags_Float,
+        # ImGuiColorEditFlags__PickerMask     = ImGuiColorEditFlags_PickerHueWheel|ImGuiColorEditFlags_PickerHueBar,
+        # ImGuiColorEditFlags__OptionsDefault = ImGuiColorEditFlags_Uint8|ImGuiColorEditFlags_RGB|ImGuiColorEditFlags_PickerHueBar    // Change application default using SetColorEditOptions()
+
+
     ctypedef enum ImGuiMouseCursor_:
         ImGuiMouseCursor_Arrow
         ImGuiMouseCursor_TextInput              # When hovering over InputText, etc.

--- a/imgui/enums.pxd
+++ b/imgui/enums.pxd
@@ -91,11 +91,11 @@ cdef extern from "imgui.h":
         ImGuiAlign_VCenter
         ImGuiAlign_Default
 
-    ctypedef enum ImGuiSetCond_:
-        ImGuiSetCond_Always               # Set the variable
-        ImGuiSetCond_Once                 # Only set the variable on the first call per runtime session
-        ImGuiSetCond_FirstUseEver         # Only set the variable if the window doesn't exist in the .ini file
-        ImGuiSetCond_Appearing            # Only set the variable if the window is appearing after being inactive (or the first time)
+    ctypedef enum ImGuiCond_:
+        ImGuiCond_Always               # Set the variable
+        ImGuiCond_Once                 # Only set the variable on the first call per runtime session
+        ImGuiCond_FirstUseEver         # Only set the variable if the window doesn't exist in the .ini file
+        ImGuiCond_Appearing            # Only set the variable if the window is appearing after being inactive (or the first time)
 
     ctypedef enum ImGuiWindowFlags_:
         ImGuiWindowFlags_NoTitleBar                 # Disable title-bar


### PR DESCRIPTION
Hey @swistakm, this is my first pass on the breaking changes in 1.51. Migrating to 1.51 is needed for #52 and is probably just good to do in general.

There are plenty of non-breaking changes (such as ColorEditFlags being added, and SetColumnWidth being added) that I didn't do.

What do you do to test this? Does the cython compilation step ensure enough typesafety that we can be sure it's good? Should I make a "1.51 demo" app?

Here's the checklist I was working off on. Sorry that my commits are in a semi-random order:

#### Breaking Changes 

- [x] Renamed IsItemHoveredRect() to IsItemRectHovered(). Kept inline redirection function (will obsolete).
- [x] Renamed IsMouseHoveringWindow() to IsWindowRectHovered() for consistency. Kept inline redirection function (will obsolete).
- [x] Renamed IsMouseHoveringAnyWindow() to IsAnyWindowHovered() for consistency. Kept inline redirection function (will obsolete).
- [x] Renamed ImGuiCol_Columns*** enums to ImGuiCol_Separator***. Kept redirection enums (will obsolete). (Not relevant, because not implemented)
- [x] Renamed ImGuiSetCond*** types and enums to ImGuiCond***. Kept redirection enums (will obsolete).
- [x] Renamed GetStyleColName() to GetStyleColorName() for consistency. Unlikely to be used by end-user!
- [x] Added PushStyleColor(ImGuiCol idx, ImU32 col) overload, which might cause an "ambiguous call" compilation error if you are using ImColor() with implicit cast. Cast to ImU32 or ImVec4 explicily to fix.
- [x] Marked the weird IMGUI_ONCE_UPON_A_FRAME helper macro as obsolete. Prefer using the more explicit ImGuiOnceUponAFrame.
- [x] Changed ColorEdit4(const char* label, float col[4], bool show_alpha = true) signature to ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags = 0), where flags 0x01 is a safe no-op (hello dodgy backward compatibility!). The new ColorEdit4/ColorPicker4 functions have lots of available flags! Check and run the demo window, under "Color/Picker Widgets", to understand the various new options.
- [x] Changed signature of ColorButton(ImVec4 col, bool small_height = false, bool outline_border = true) to ColorButton(const char* desc_id, ImVec4 col, ImGuiColorEditFlags flags = 0, ImVec2 size = ImVec2(0,0)). This function was rarely used and was very dodgy (no explicit ID!).

    bool ColorButton( # ✓
        const char*, ImVec4 col,
        # note: optional
        ImGuiColorEditFlags flags, ImVec2 size 
    ) except +

- [x] Changed BeginPopupContextWindow(bool also_over_items=true, const char* str_id=NULL, int mouse_button=1) signature to (const char* str_id=NULL, int mouse_button=1, bool also_over_items=true). This is perhaps the most aggressive change in this update, but note that the majority of users relied on default parameters completely, so this will affect only a fraction of users of this already rarely used function.
- [x] Removed IsPosHoveringAnyWindow(), which was partly broken and misleading. In the vast majority of cases, people using that function wanted to use io.WantCaptureMouse flag. Replaced with IM_ASSERT + comment redirecting user to io.WantCaptureMouse. (#1237)
- [x] Removed the old ValueColor() helpers, they are equivalent to calling Text(label) + SameLine() + ColorButton().
- [x] Removed ColorEditMode() and ImGuiColorEditMode type in favor of ImGuiColorEditFlags and parameters to the various Color*() functions. The SetColorEditOptions() function allows to initialize default but the user can still change them with right-click context menu. Commenting out your old call to ColorEditMode() may just be fine!