### PR TITLE
Fix typos in SDL2 example

### DIFF
--- a/doc/examples/pysdl2.py
+++ b/doc/examples/pysdl2.py
@@ -93,7 +93,7 @@ def impl_pysdl2_init():
         exit(1)
 
     SDL_GL_MakeCurrent(window, gl_context)
-    if SDL_GL_SetSwapInterval(1) < 0:
+    if SDL_GL_SetSwapInterval(1) > 0:
         print("Warning: Unable to set VSync! SDL Error: " + SDL_GetError())
         exit(1)
 

--- a/doc/examples/pysdl2.py
+++ b/doc/examples/pysdl2.py
@@ -94,7 +94,7 @@ def impl_pysdl2_init():
 
     SDL_GL_MakeCurrent(window, gl_context)
     if SDL_GL_SetSwapInterval(1) > 0:
-        print("Warning: Unable to set VSync! SDL Error: " + SDL_GetError())
+        print("Warning: Unable to set VSync! SDL Error: ", SDL_GetError())
         exit(1)
 
     return window, gl_context


### PR DESCRIPTION
I read through the OpenGL docs and I think I found a typo that caused the example to crash *unless* VSync fails. I believe this is not what you wanted. :p