### PR TITLE
Additional funcs 20180527

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![completion](https://img.shields.io/badge/completion-66%25%20%28294%20of%20442%29-blue.svg)](https://github.com/swistakm/pyimgui)
+[![completion](https://img.shields.io/badge/completion-69%25%20%28308%20of%20443%29-blue.svg)](https://github.com/swistakm/pyimgui)
 [![Coverage Status](https://coveralls.io/repos/github/swistakm/pyimgui/badge.svg?branch=master)](https://coveralls.io/github/swistakm/pyimgui?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/pyimgui/badge/?version=latest)](https://pyimgui.readthedocs.io/en/latest/?badge=latest)
 

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -201,11 +201,18 @@ cdef extern from "imgui.h":
 
 
     ctypedef struct ImDrawList:
-        # we mapp only buffer vectors since everything else is internal
+        # we map only buffer vectors since everything else is internal
         # and right now we dont want to suport it.
         ImVector[ImDrawCmd]  CmdBuffer  # ✓
         ImVector[ImDrawIdx]  IdxBuffer  # ✓
         ImVector[ImDrawVert] VtxBuffer  # ✓
+
+        void  AddRectFilled(
+                   const ImVec2&, 
+                   const ImVec2&, 
+                   ImU32,
+                   # note: optional
+                   float, int) except +  # ✓
 
 
     ctypedef struct ImDrawData:  # ✓
@@ -326,7 +333,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     bool ShowStyleSelector(const char*) except +  # ✓
     void ShowFontSelector(const char*) except +  # ✓
     void ShowUserGuide() except +  # ✓
-    const char*   GetVersion() except +  # ✗
+    const char* GetVersion() except +  # ✓
 
     void StyleColorsDark(ImGuiStyle* dst) except +  # ✓
     void StyleColorsClassic(ImGuiStyle* dst) except +  # ✓
@@ -459,9 +466,9 @@ cdef extern from "imgui.h" namespace "ImGui":
     ImFont* GetFont() except +  # ✗
     float GetFontSize() except +  # ✓
     ImVec2 GetFontTexUvWhitePixel() except +  # ✗
-    ImU32 GetColorU32(ImGuiCol, float) except +  # ✗
-    ImU32 GetColorU32(const ImVec4& col) except +  # ✗
-    ImU32 GetColorU32(ImU32 col) except +  # ✗
+    ImU32 GetColorU32(ImGuiCol, float) except +  # ✓
+    ImU32 GetColorU32(const ImVec4& col) except +  # ✓
+    ImU32 GetColorU32(ImU32 col) except +  # ✓
 
     # ====
     # Parameters stacks (current window)
@@ -500,14 +507,14 @@ cdef extern from "imgui.h" namespace "ImGui":
     void SetCursorPos(const ImVec2& local_pos) except +  # ✗
     void SetCursorPosX(float x) except +  # ✗
     void SetCursorPosY(float y) except +  # ✗
-    ImVec2 GetCursorStartPos() except +  # ✗
-    ImVec2 GetCursorScreenPos() except +  # ✗
+    ImVec2 GetCursorStartPos() except +  # ✓
+    ImVec2 GetCursorScreenPos() except +  # ✓
     void SetCursorScreenPos(const ImVec2& screen_pos) except +  # ✗
     void AlignTextToFramePadding() except +  # ✗
-    float GetTextLineHeight() except +  # ✗
-    float GetTextLineHeightWithSpacing() except +  # ✗
-    float GetFrameHeight() except +  # ✗
-    float GetFrameHeightWithSpacing() except +  # ✗
+    float GetTextLineHeight() except +  # ✓
+    float GetTextLineHeightWithSpacing() except +  # ✓
+    float GetFrameHeight() except +  # ✓
+    float GetFrameHeightWithSpacing() except +  # ✓
 
     # ====
     # ID scopes
@@ -1085,7 +1092,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     ImDrawList* GetOverlayDrawList() except +  # ✗
     ImDrawListSharedData* GetDrawListSharedData() except +  # ✗
 
-    const char* GetStyleColName(ImGuiCol idx) except +  # ✗
+    const char* GetStyleColorName(ImGuiCol idx) except +  # ✓
 
     void SetStateStorage(ImGuiStorage* storage) except +  # ✗
     ImGuiStorage* GetStateStorage() except +  # ✗

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -339,8 +339,8 @@ cdef extern from "imgui.h" namespace "ImGui":
     void StyleColorsClassic(ImGuiStyle* dst) except +  # ✓
     void StyleColorsLight(ImGuiStyle* dst) except +  # ✓
 
-    void SetItemDefaultFocus() except +  # ✗
-    void SetKeyboardFocusHere(int offset) except +  # ✗
+    void SetItemDefaultFocus() except +  # ✓
+    void SetKeyboardFocusHere(int offset) except +  # ✓
 
 
     # ====

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -1733,6 +1733,29 @@ def get_window_draw_list():
     It may be useful if you want to do your own drawing via the DrawList
     api.
 
+    .. visual-example::
+        :auto_layout:
+        :height: 100
+        :width: 200
+        :click: 10 10
+
+
+        pos_x = 10
+        pos_y = 10
+        sz = 20
+
+        draw_list = imgui.get_window_draw_list()
+
+        for i in range(0, imgui.COLOR_COUNT):
+            name = imgui.get_style_color_name(i);
+            draw_list.add_rect_filled(pos_x, pos_y, pos_x+sz, pos_y+sz, imgui.get_color_u32_idx(i));
+            imgui.dummy(sz, sz);
+            imgui.same_line();
+
+        rgba_color = imgui.get_color_u32_rgba(1, 1, 0, 1);
+        draw_list.add_rect_filled(pos_x, pos_y, pos_x+sz, pos_y+sz, rgba_color);
+
+
     Returns:
         ImDrawList*
 

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -375,6 +375,44 @@ cdef class _DrawList(object):
     def idx_buffer_data(self):
         return <uintptr_t>self._ptr.IdxBuffer.Data
 
+    def add_rect_filled(self,
+        float upper_left_x, float upper_left_y,
+        float lower_right_x, float lower_right_y,
+        cimgui.ImU32 col,
+        # note: optional
+        float rounding = 0.0, cimgui.ImGuiWindowFlags rounding_corners_flags = 0xF):
+
+        """AddRectFilled() primitive for ImDrawList()
+
+    Args:
+        closable (bool): define if window is closable.
+        upper_left_x (float): X coordinate of top-left
+        upper_left_y (float): Y coordinate of top-left
+        lower_right_x (float): X coordinate of lower-right
+        lower_right_y (float): Y coordinate of lower-right
+        col (ImU32): RGBA color specification
+        # note: optional
+        rounding (float): Degree of rounding, defaults to 0.0
+        rounding_corners_flags (ImDrawCornerFlags): Draw flags, defaults to ImDrawCornerFlags_ALL
+
+    .. wraps::
+        void  AddRectFilled(
+                   const ImVec2&,
+                   const ImVec2&,
+                   ImU32,
+                   # note: optional
+                   float, int)
+    """
+        #_DrawList.from_ptr(self._ptr).AddRectFilled(
+        self._ptr.AddRectFilled(
+            _cast_args_ImVec2(upper_left_x, upper_left_y),
+            _cast_args_ImVec2(lower_right_x, lower_right_y),
+            col,
+            rounding,
+            rounding_corners_flags
+        )
+
+
     @property
     def commands(self):
         return [
@@ -1165,6 +1203,18 @@ def show_user_guide():
     cimgui.ShowUserGuide()
 
 
+def get_version():
+    """Get the version of Dear ImGui.
+
+    .. wraps::
+        void GetVersion()
+    """
+    cdef const char* c_string = cimgui.GetVersion()
+    cdef bytes py_string = c_string
+    return c_string.decode("utf-8")
+
+
+
 def show_style_editor(GuiStyle style=None):
     """Show ImGui style editor.
 
@@ -1232,6 +1282,7 @@ def show_test_window():
         void ShowDemoWindow()
     """
     cimgui.ShowDemoWindow()
+
 
 
 def show_metrics_window(closable=False):
@@ -1632,6 +1683,21 @@ def set_next_window_bg_alpha(float alpha):
         void SetNextWindowBgAlpha(float)
     """
     cimgui.SetNextWindowBgAlpha(alpha)
+
+
+def get_window_draw_list():
+    """Get the draw list associated with the window, to append your own drawing primitives
+
+    It may be useful if you want to do your own drawing via the DrawList
+    api.
+
+    Returns:
+        ImDrawList*
+
+    .. wraps::
+        ImDrawList* GetWindowDrawList()
+    """
+    return _DrawList.from_ptr(cimgui.GetWindowDrawList())
 
 
 def get_window_position():
@@ -4975,6 +5041,17 @@ def is_rect_visible(float size_width, float size_height):
     return cimgui.IsRectVisible(_cast_args_ImVec2(size_width, size_height))
 
 
+def get_style_color_name(int index):
+    """Get the style color name for a given ImGuiCol index.
+
+    .. wraps::
+        const char* GetStyleColorName(ImGuiCol idx) except +  # ✓
+    """
+    cdef const char* c_string = cimgui.GetStyleColorName(index)
+    cdef bytes py_string = c_string
+    return c_string.decode("utf-8")
+
+
 def is_mouse_hovering_rect(
     float r_min_x, float r_min_y,
     float r_max_x, float r_max_y,
@@ -5288,6 +5365,46 @@ cpdef get_font_size():
     """
     return cimgui.GetFontSize()
 
+
+
+# TODO: Can we implement function overloading? Prefer these are all named 'get_color_u32' with different signatures
+# https://www.python.org/dev/peps/pep-0443/
+
+
+cpdef get_color_u32_idx(cimgui.ImGuiCol idx, float alpha_mul = 1.0):
+    """ retrieve given style color with style alpha applied and optional extra alpha multiplier
+
+    Returns:
+        ImU32: 32-bit RGBA color
+
+    .. wraps::
+        ImU32 GetColorU32(ImGuiCol idx, alpha_mul)
+    """
+    return cimgui.GetColorU32(idx, alpha_mul)
+
+
+cpdef get_color_u32_rgba(float r, float g, float b, float a):
+    """ retrieve given color with style alpha applied
+
+    Returns:
+        ImU32: 32-bit RGBA color
+
+    .. wraps::
+        ImU32 GetColorU32(const ImVec4& col)
+    """
+    return cimgui.GetColorU32( _cast_args_ImVec4(r, g, b, a) )
+
+
+cpdef get_color_u32(cimgui.ImU32 col):
+    """retrieve given style color with style alpha applied and optional extra alpha multiplier
+
+    Returns:
+        ImU32: 32-bit RGBA color
+
+    .. wraps::
+        ImU32 GetColorU32(ImU32 col)
+    """
+    return cimgui.GetColorU32(col)
 
 
 
@@ -5796,6 +5913,67 @@ def end_group():
         void EndGroup()
     """
     cimgui.EndGroup()
+
+
+def get_cursor_start_pos():
+    """Get the initial cursor position.
+
+    .. wraps::
+        ImVec2 GetCursorStartPos()
+    """
+    return _cast_ImVec2_tuple(cimgui.GetCursorStartPos())
+
+
+def get_cursor_screen_pos():
+    """Get the cursor position in absolute screen coordinates [0..io.DisplaySize] (useful to work with ImDrawList API)
+
+    .. wraps::
+        ImVec2 GetCursorScreenPos()
+    """
+    return _cast_ImVec2_tuple(cimgui.GetCursorScreenPos())
+
+
+def get_text_line_height():
+    """Get text line height.
+
+    Returns:
+        int: text line height.
+
+    .. wraps::
+        void GetTextLineHeight()
+    """
+    return cimgui.GetTextLineHeight()
+
+
+def get_text_line_height_with_spacing():
+    """Get text line height, with spacing.
+
+    Returns:
+        int: text line height, with spacing.
+
+    .. wraps::
+        void GetTextLineHeightWithSpacing()
+    """
+    return cimgui.GetTextLineHeightWithSpacing()
+
+
+def get_frame_height():
+    """~ FontSize + style.FramePadding.y * 2
+
+    .. wraps::
+        float GetFrameHeight()
+    float GetFrameHeightWithSpacing() except +  # ✗
+    """
+    return cimgui.GetFrameHeight()
+
+
+def get_frame_height_with_spacing():
+    """~ FontSize + style.FramePadding.y * 2 + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of framed widgets)
+
+    .. wraps::
+        float GetFrameHeightWithSpacing()
+    """
+    return cimgui.GetFrameHeightWithSpacing()
 
 
 def create_context(_FontAtlas shared_font_atlas = None):

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -5369,7 +5369,7 @@ cpdef get_font_size():
 
 # TODO: Can we implement function overloading? Prefer these are all named 'get_color_u32' with different signatures
 # https://www.python.org/dev/peps/pep-0443/
-
+# Neither singledispatch nor multipledispatch seems to be available in Cython :-/
 
 cpdef get_color_u32_idx(cimgui.ImGuiCol idx, float alpha_mul = 1.0):
     """ retrieve given style color with style alpha applied and optional extra alpha multiplier

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -1214,6 +1214,51 @@ def get_version():
     return c_string.decode("utf-8")
 
 
+def style_colors_dark(GuiStyle dst = None):
+    """Set the style to Dark.
+
+       new, recommended style (default)
+
+    .. wraps::
+        void StyleColorsDark(ImGuiStyle* dst = NULL)
+    """
+    if dst:
+        cimgui.StyleColorsDark(&dst.ref)
+    else:
+        cimgui.StyleColorsDark(NULL)
+
+
+def style_colors_classic(GuiStyle dst = None):
+    """Set the style to Classic.
+
+       classic imgui style.
+
+    .. wraps::
+        void StyleColorsClassic(ImGuiStyle* dst = NULL)
+    """
+    if dst:
+        cimgui.StyleColorsClassic(&dst.ref)
+    else:
+        cimgui.StyleColorsClassic(NULL)
+
+
+
+# TODO: These style_colors_x functions don't currently return anything
+#       We need to ensure the dst is being set correctly
+
+def style_colors_light(GuiStyle dst = None):
+    """Set the style to Light.
+
+       best used with borders and a custom, thicker font
+
+    .. wraps::
+        void StyleColorsLight(ImGuiStyle* dst = NULL)
+    """
+    if dst:
+        cimgui.StyleColorsLight(&dst.ref)
+    else:
+        cimgui.StyleColorsLight(NULL)
+
 
 def show_style_editor(GuiStyle style=None):
     """Show ImGui style editor.

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -1243,9 +1243,6 @@ def style_colors_classic(GuiStyle dst = None):
 
 
 
-# TODO: These style_colors_x functions don't currently return anything
-#       We need to ensure the dst is being set correctly
-
 def style_colors_light(GuiStyle dst = None):
     """Set the style to Light.
 
@@ -4890,6 +4887,26 @@ def v_slider_int(
         <int*>&inout_value,
         min_value, max_value, _bytes(format)
     ), inout_value
+
+
+def set_item_default_focus():
+    """Make last item the default focused item of a window.
+    Please use instead of "if (is_window_appearing()) set_scroll_here()" to signify "default item".
+
+    .. wraps::
+        void SetItemDefaultFocus()
+    """
+    cimgui.SetItemDefaultFocus()
+
+
+def set_keyboard_focus_here(int offset = 0):
+    """Focus keyboard on the next widget.
+    Use positive 'offset' to access sub components of a multiple component widget. Use -1 to access previous widget.
+
+    .. wraps::
+        void SetKeyboardFocusHere(int offset = 0)
+    """
+    return cimgui.SetKeyboardFocusHere(offset)
 
 
 def is_item_hovered(


### PR DESCRIPTION
Added support for
```
 SetItemDefaultFocus
 SetKeyboardFocusHere
 StyleColorsDark
 StyleColorsClassic
 StyleColorsLight
 AddRectFilled
 GetVersion
 GetCursorStartPos
 GetCursorScreenPos
 GetTextLineHeight
 GetTextLineHeightWithSpacing
 GetFrameHeight
 GetFrameHeightWithSpacing
 GetStyleColorName
 GetColorU32
```

Regarding GetColorU32..  These are overloaded functions in ImGui, and I was unable to find any way of supporting single/multiple dispatch with Cython.
That means we're left with 3 distinct cpdefs in order to support the 3 function signatures.
```
 get_color_u32
 get_color_u32_idx
 get_color_u32_rgba
```

