### PR TITLE
Add trailing null byte to combo item list

### DIFF
--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -3243,7 +3243,7 @@ def combo(str label, int current, list items, int height_in_items=-1):
     """
     cdef int inout_current = current
 
-    in_items = "\0".join(items)
+    in_items = "\0".join(items) + "\0"
 
     return cimgui.Combo(
         _bytes(label), &inout_current, _bytes(in_items), height_in_items


### PR DESCRIPTION
The last item in the combo item list `in_items` wasn't terminated correctly, leading to garbage data ending up in the list.