### PR TITLE
Upgrade to imgui 1.65

### DIFF
--- a/imgui/__init__.py
+++ b/imgui/__init__.py
@@ -38,7 +38,7 @@ KEY_TAB = core.KEY_TAB
 #: for text edit
 KEY_LEFT_ARROW = core.KEY_LEFT_ARROW
 #: for text edit
-KEY_RIGHT_ARROW = core.KEY_UP_ARROW
+KEY_RIGHT_ARROW = core.KEY_RIGHT_ARROW
 #: for text edit
 KEY_UP_ARROW = core.KEY_UP_ARROW
 #: for text edit
@@ -155,9 +155,6 @@ WINDOW_ALWAYS_HORIZONTAL_SCROLLBAR = core.WINDOW_ALWAYS_HORIZONTAL_SCROLLBAR
 #: Ensure child windows without border uses style.WindowPadding (ignored by
 #: default for non-bordered child windows, because more convenient).
 WINDOW_ALWAYS_USE_WINDOW_PADDING = core.WINDOW_ALWAYS_USE_WINDOW_PADDING
-#: Enable resize from any borners and borders. Your back-end needs to honour
-# the different values of io.MouseCursor set by imgui.
-WINDOW_RESIZE_FROM_ANY_SIDE = core.WINDOW_RESIZE_FROM_ANY_SIDE
 # No gamepad/keyboard navigation within the window
 WINDOW_NO_NAV_INPUTS = core.WINDOW_NO_NAV_INPUTS
 # No focusing toward this window with gamepad/keyboard navigation
@@ -237,10 +234,11 @@ COLOR_PLOT_LINES_HOVERED = core.COLOR_PLOT_LINES_HOVERED
 COLOR_PLOT_HISTOGRAM = core.COLOR_PLOT_HISTOGRAM
 COLOR_PLOT_HISTOGRAM_HOVERED = core.COLOR_PLOT_HISTOGRAM_HOVERED
 COLOR_TEXT_SELECTED_BACKGROUND = core.COLOR_TEXT_SELECTED_BACKGROUND
-COLOR_MODAL_WINDOW_DARKENING = core.COLOR_MODAL_WINDOW_DARKENING
 COLOR_DRAG_DROP_TARGET = core.COLOR_DRAG_DROP_TARGET
 COLOR_NAV_HIGHLIGHT = core.COLOR_NAV_HIGHLIGHT
 COLOR_NAV_WINDOWING_HIGHLIGHT = core.COLOR_NAV_WINDOWING_HIGHLIGHT
+COLOR_NAV_WINDOWING_DIM_BACKGROUND = core.COLOR_NAV_WINDOWING_DIM_BACKGROUND
+COLOR_MODAL_WINDOW_DIM_BACKGROUND = core.COLOR_MODAL_WINDOW_DIM_BACKGROUND
 COLOR_COUNT = core.COLOR_COUNT
 
 # === Selectable flag constants (redefines for autodoc)
@@ -286,7 +284,7 @@ FOCUS_ROOT_AND_CHILD_WINDOWS = core.FOCUS_CHILD_WINDOWS | core.FOCUS_ROOT_WINDOW
 #: Return true if directly over the item/window, not obstructed by
 #: another window, not obstructed by an active popup or modal
 #: blocking inputs under them.
-HOVERED_DEFAULT = core.HOVERED_DEFAULT
+HOVERED_NONE = core.HOVERED_NONE
 #: IsWindowHovered() only: Return true if any children of the window is hovered
 HOVERED_CHILD_WINDOWS = core.HOVERED_CHILD_WINDOWS
 #: IsWindowHovered() only: Test from root window (top most parent of the current hierarchy)
@@ -326,6 +324,9 @@ DRAG_DROP_SOURCE_ALLOW_NULL_ID = core.DRAG_DROP_SOURCE_ALLOW_NULL_ID
 #: item/window info. Will always return true. Only one Extern source can
 #: be active simultaneously.
 DRAG_DROP_SOURCE_EXTERN = core.DRAG_DROP_SOURCE_EXTERN
+#: Automatically expire the payload if the source cease to be submitted
+#: (otherwise payloads are persisting while being dragged)
+DRAG_DROP_SOURCE_AUTO_EXPIRE_PAYLOAD = core.DRAG_DROP_SOURCE_AUTO_EXPIRE_PAYLOAD
 
 # === Accept Drag Drop Payload flag constants (redefines for autodoc)
 #: AcceptDragDropPayload() will returns true even before the mouse button

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -30,7 +30,7 @@ cdef extern from "imgui.h":
     # ctypedef struct ImGuiStyle  # declared later
     ctypedef struct ImGuiTextFilter
     ctypedef struct ImGuiTextBuffer
-    ctypedef struct ImGuiTextEditCallbackData
+    ctypedef struct ImGuiInputTextCallbackData
     ctypedef struct ImGuiSizeCallbackData
     ctypedef struct ImGuiListClipper
     ctypedef struct ImGuiPayload
@@ -65,7 +65,7 @@ cdef extern from "imgui.h":
     ctypedef int ImGuiSelectableFlags
     ctypedef int ImGuiTreeNodeFlags
     ctypedef int ImGuiWindowFlags
-    ctypedef int (*ImGuiTextEditCallback)(ImGuiTextEditCallbackData *data);
+    ctypedef int (*ImGuiInputTextCallback)(ImGuiInputTextCallbackData *data);
     ctypedef void (*ImGuiSizeCallback)(ImGuiSizeCallbackData* data);
 
     ctypedef struct ImVec2:
@@ -105,8 +105,9 @@ cdef extern from "imgui.h":
         ImVec2        DisplayFramebufferScale  # ✓
         ImVec2        DisplayVisibleMin  # ✓
         ImVec2        DisplayVisibleMax  # ✓
-        bool          OptMacOSXBehaviors  # ✓
-        bool          OptCursorBlink  # ✓
+        bool          ConfigMacOSXBehaviors  # ✓
+        bool          ConfigInputTextCursorBlink  # ✓
+        bool          ConfigResizeWindowsFromEdges  # ✓
 
         # ====
         # source-note: User Functions
@@ -254,7 +255,8 @@ cdef extern from "imgui.h":
         const ImWchar* GetGlyphRangesDefault() except +  # ✓
         const ImWchar* GetGlyphRangesKorean() except +  # ✓
         const ImWchar* GetGlyphRangesJapanese() except +  # ✓
-        const ImWchar* GetGlyphRangesChinese() except +  # ✓
+        const ImWchar* GetGlyphRangesChineseFull() except +  # ✓
+        const ImWchar* GetGlyphRangesChineseSimplifiedCommon() except +  # ✓
         const ImWchar* GetGlyphRangesCyrillic() except +  # ✓
 
 
@@ -724,13 +726,13 @@ cdef extern from "imgui.h" namespace "ImGui":
             const char* label, char* buf, size_t buf_size,
             # note: optional
             ImGuiInputTextFlags flags,
-            ImGuiTextEditCallback callback, void* user_data
+            ImGuiInputTextCallback callback, void* user_data
     ) except +
     bool InputTextMultiline(  # ✓
             const char* label, char* buf, size_t buf_size,
             # note: optional
             const ImVec2& size, ImGuiInputTextFlags flags,
-            ImGuiTextEditCallback callback, void* user_data
+            ImGuiInputTextCallback callback, void* user_data
     ) except +
     bool InputFloat(  # ✓
             const char* label, float* v,
@@ -1087,7 +1089,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     ImVec2 GetItemRectSize() except +  # ✓
     void SetItemAllowOverlap() except +  # ✓
     bool IsRectVisible(const ImVec2& size) except +  # ✓
-    float GetTime() except +  # ✗
+    double GetTime() except +  # ✗
     int GetFrameCount() except +  # ✗
     ImDrawList* GetOverlayDrawList() except +  # ✗
     ImDrawListSharedData* GetDrawListSharedData() except +  # ✗

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -1,5 +1,5 @@
 # distutils: language = c++
-# distutils: sources = imgui-cpp/imgui.cpp imgui-cpp/imgui_draw.cpp imgui-cpp/imgui_demo.cpp config-cpp/py_imconfig.cpp
+# distutils: sources = imgui-cpp/imgui.cpp imgui-cpp/imgui_draw.cpp imgui-cpp/imgui_demo.cpp imgui-cpp/imgui_widgets.cpp config-cpp/py_imconfig.cpp
 # distutils: include_dirs = imgui-cpp
 # cython: embedsignature=True
 """
@@ -105,7 +105,6 @@ WINDOW_NO_BRING_TO_FRONT_ON_FOCUS = enums.ImGuiWindowFlags_NoBringToFrontOnFocus
 WINDOW_ALWAYS_VERTICAL_SCROLLBAR = enums.ImGuiWindowFlags_AlwaysVerticalScrollbar
 WINDOW_ALWAYS_HORIZONTAL_SCROLLBAR = enums.ImGuiWindowFlags_AlwaysHorizontalScrollbar
 WINDOW_ALWAYS_USE_WINDOW_PADDING = enums.ImGuiWindowFlags_AlwaysUseWindowPadding
-WINDOW_RESIZE_FROM_ANY_SIDE = enums.ImGuiWindowFlags_ResizeFromAnySide
 WINDOW_NO_NAV_INPUTS = enums.ImGuiWindowFlags_NoNavInputs
 WINDOW_NO_NAV_FOCUS = enums.ImGuiWindowFlags_NoNavFocus
 WINDOW_NO_NAV = enums.ImGuiWindowFlags_NoNav
@@ -147,7 +146,7 @@ FOCUS_ANY_WINDOW = enums.ImGuiFocusedFlags_AnyWindow
 FOCUS_ROOT_AND_CHILD_WINDOWS = enums.ImGuiFocusedFlags_RootAndChildWindows
 
 # === Hovered flag enum redefines ====
-HOVERED_DEFAULT = enums.ImGuiHoveredFlags_Default
+HOVERED_NONE = enums.ImGuiHoveredFlags_None
 HOVERED_CHILD_WINDOWS = enums.ImGuiHoveredFlags_ChildWindows
 HOVERED_ROOT_WINDOW = enums.ImGuiHoveredFlags_RootWindow
 HOVERED_ANY_WINDOW = enums.ImGuiHoveredFlags_AnyWindow
@@ -163,10 +162,12 @@ DRAG_DROP_SOURCE_NO_DISABLE_HOVER = enums.ImGuiDragDropFlags_SourceNoDisableHove
 DRAG_DROP_SOURCE_NO_HOLD_TO_OPEN_OTHERS = enums.ImGuiDragDropFlags_SourceNoHoldToOpenOthers
 DRAG_DROP_SOURCE_ALLOW_NULL_ID = enums.ImGuiDragDropFlags_SourceAllowNullID
 DRAG_DROP_SOURCE_EXTERN = enums.ImGuiDragDropFlags_SourceExtern
+DRAG_DROP_SOURCE_AUTO_EXPIRE_PAYLOAD = enums.ImGuiDragDropFlags_SourceAutoExpirePayload
 
 # === Accept Drag Drop Payload flag enum redefines ====
 DRAG_DROP_ACCEPT_BEFORE_DELIVERY = enums.ImGuiDragDropFlags_AcceptBeforeDelivery
 DRAG_DROP_ACCEPT_NO_DRAW_DEFAULT_RECT = enums.ImGuiDragDropFlags_AcceptNoDrawDefaultRect
+DRAG_DROP_ACCEPT_NO_PREVIEW_TOOLTIP = enums.ImGuiDragDropFlags_AcceptNoPreviewTooltip
 DRAG_DROP_ACCEPT_PEEK_ONLY = enums.ImGuiDragDropFlags_AcceptPeekOnly
 
 # === Cardinal Direction enum redefines ====
@@ -224,10 +225,11 @@ COLOR_PLOT_LINES_HOVERED = enums.ImGuiCol_PlotLinesHovered
 COLOR_PLOT_HISTOGRAM = enums.ImGuiCol_PlotHistogram
 COLOR_PLOT_HISTOGRAM_HOVERED = enums.ImGuiCol_PlotHistogramHovered
 COLOR_TEXT_SELECTED_BACKGROUND = enums.ImGuiCol_TextSelectedBg
-COLOR_MODAL_WINDOW_DARKENING = enums.ImGuiCol_ModalWindowDarkening
 COLOR_DRAG_DROP_TARGET = enums.ImGuiCol_DragDropTarget
 COLOR_NAV_HIGHLIGHT = enums.ImGuiCol_NavHighlight
 COLOR_NAV_WINDOWING_HIGHLIGHT = enums.ImGuiCol_NavWindowingHighlight
+COLOR_NAV_WINDOWING_DIM_BACKGROUND = enums.ImGuiCol_NavWindowingDimBg
+COLOR_MODAL_WINDOW_DIM_BACKGROUND = enums.ImGuiCol_ModalWindowDimBg
 COLOR_COUNT = enums.ImGuiCol_COUNT
 
 # ==== Text input flags ====
@@ -809,8 +811,11 @@ cdef class _FontAtlas(object):
     def get_glyph_ranges_japanese(self):
         return _StaticGlyphRanges.from_ptr(self._ptr.GetGlyphRangesJapanese())
 
+    def get_glyph_ranges_chinese_full(self):
+        return _StaticGlyphRanges.from_ptr(self._ptr.GetGlyphRangesChineseFull())
+
     def get_glyph_ranges_chinese(self):
-        return _StaticGlyphRanges.from_ptr(self._ptr.GetGlyphRangesChinese())
+        return _StaticGlyphRanges.from_ptr(self._ptr.GetGlyphRangesChineseSimplifiedCommon())
 
     def get_glyph_ranges_cyrillic(self):
         return _StaticGlyphRanges.from_ptr(self._ptr.GetGlyphRangesCyrillic())
@@ -993,20 +998,28 @@ cdef class _IO(object):
         self._ptr.DisplayVisibleMax = _cast_tuple_ImVec2(value)
 
     @property
-    def opt_mac_osx_behaviors(self):
-        return self._ptr.OptMacOSXBehaviors
+    def config_mac_osx_behaviors(self):
+        return self._ptr.ConfigMacOSXBehaviors
 
-    @opt_mac_osx_behaviors.setter
-    def opt_mac_osx_behaviors(self, cimgui.bool value):
-        self._ptr.OptMacOSXBehaviors = value
+    @config_mac_osx_behaviors.setter
+    def config_mac_osx_behaviors(self, cimgui.bool value):
+        self._ptr.ConfigMacOSXBehaviors = value
 
     @property
-    def opt_cursor_blink(self):
-        return self._ptr.OptCursorBlink
+    def config_cursor_blink(self):
+        return self._ptr.ConfigInputTextCursorBlink
 
-    @opt_cursor_blink.setter
-    def opt_cursor_blink(self, cimgui.bool value):
-        self._ptr.OptCursorBlink = value
+    @config_cursor_blink.setter
+    def config_cursor_blink(self, cimgui.bool value):
+        self._ptr.ConfigInputTextCursorBlink = value
+
+    @property
+    def config_resize_windows_from_edges(self):
+        return self._ptr.ConfigResizeWindowsFromEdges
+
+    @config_resize_windows_from_edges.setter
+    def config_resize_windows_from_edges(self, cimgui.bool value):
+        self._ptr.ConfigResizeWindowsFromEdges = value
 
     @property
     def mouse_pos(self):
@@ -3834,7 +3847,7 @@ def input_text(
             char* buf,
             size_t buf_size,
             ImGuiInputTextFlags flags = 0,
-            ImGuiTextEditCallback callback = NULL,
+            ImGuiInputTextCallback callback = NULL,
             void* user_data = NULL
         )
     """
@@ -3901,7 +3914,7 @@ def input_text_multiline(
             size_t buf_size,
             const ImVec2& size = ImVec2(0,0),
             ImGuiInputTextFlags flags = 0,
-            ImGuiTextEditCallback callback = NULL,
+            ImGuiInputTextCallback callback = NULL,
             void* user_data = NULL
         )
     """

--- a/imgui/enums.pxd
+++ b/imgui/enums.pxd
@@ -102,10 +102,11 @@ cdef extern from "imgui.h":
         ImGuiCol_PlotHistogram
         ImGuiCol_PlotHistogramHovered
         ImGuiCol_TextSelectedBg
-        ImGuiCol_ModalWindowDarkening  # Darken entire screen when a modal window is active
         ImGuiCol_DragDropTarget
-        ImGuiCol_NavHighlight
-        ImGuiCol_NavWindowingHighlight
+        ImGuiCol_NavHighlight,          # Gamepad/keyboard: current highlighted item
+        ImGuiCol_NavWindowingHighlight, # Highlight window when using CTRL+TAB
+        ImGuiCol_NavWindowingDimBg,     # Darken/colorize entire screen behind the CTRL+TAB window list, when active
+        ImGuiCol_ModalWindowDimBg,      # Darken/colorize entire screen behind a modal window, when one is active
         ImGuiCol_COUNT
 
     ctypedef enum ImGuiDataType_:
@@ -172,7 +173,6 @@ cdef extern from "imgui.h":
         ImGuiWindowFlags_AlwaysVerticalScrollbar    # Always show vertical scrollbar (even if ContentSize.y < Size.y)
         ImGuiWindowFlags_AlwaysHorizontalScrollbar  # Always show horizontal scrollbar (even if ContentSize.x < Size.x)
         ImGuiWindowFlags_AlwaysUseWindowPadding     # Ensure child windows without border uses style.WindowPadding (ignored by default for non-bordered child windows, because more convenient)
-        ImGuiWindowFlags_ResizeFromAnySide          # [BETA] Enable resize from any corners and borders. Your back-end needs to honor the different values of io.MouseCursor set by imgui.
         ImGuiWindowFlags_NoNavInputs                # No gamepad/keyboard navigation within the window
         ImGuiWindowFlags_NoNavFocus                 # No focusing toward this window with gamepad/keyboard navigation (e.g. skipped by CTRL+TAB)
         ImGuiWindowFlags_NoNav = ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus 
@@ -243,7 +243,7 @@ cdef extern from "imgui.h":
         ImGuiFocusedFlags_RootAndChildWindows   # ImGuiFocusedFlags_RootWindow | ImGuiFocusedFlags_ChildWindows
 
     ctypedef enum ImGuiHoveredFlags_:
-        ImGuiHoveredFlags_Default                       # Return true if directly over the item/window, not obstructed by another window, not obstructed by an active popup or modal blocking inputs under them.
+        ImGuiHoveredFlags_None                          # Return true if directly over the item/window, not obstructed by another window, not obstructed by an active popup or modal blocking inputs under them.
         ImGuiHoveredFlags_ChildWindows                  # IsWindowHovered() only: Return true if any children of the window is hovered
         ImGuiHoveredFlags_RootWindow                    # IsWindowHovered() only: Test from root window (top most parent of the current hierarchy)
         ImGuiHoveredFlags_AnyWindow
@@ -260,9 +260,11 @@ cdef extern from "imgui.h":
         ImGuiDragDropFlags_SourceNoHoldToOpenOthers     # Disable the behavior that allows to open tree nodes and collapsing header by holding over them while dragging a source item.
         ImGuiDragDropFlags_SourceAllowNullID            # Allow items such as Text(), Image() that have no unique identifier to be used as drag source, by manufacturing a temporary identifier based on their window-relative position. This is extremely unusual within the dear imgui ecosystem and so we made it explicit.
         ImGuiDragDropFlags_SourceExtern                 # External source (from outside of imgui), won't attempt to read current item/window info. Will always return true. Only one Extern source can be active simultaneously.
+        ImGuiDragDropFlags_SourceAutoExpirePayload      # Automatically expire the payload if the source cease to be submitted (otherwise payloads are persisting while being dragged)
         # AcceptDragDropPayload() flags
         ImGuiDragDropFlags_AcceptBeforeDelivery         # AcceptDragDropPayload() will returns true even before the mouse button is released. You can then call IsDelivery() to test if the payload needs to be delivered.
         ImGuiDragDropFlags_AcceptNoDrawDefaultRect      # Do not draw the default highlight rectangle when hovering over target.
+        ImGuiDragDropFlags_AcceptNoPreviewTooltip       # Request hiding the BeginDragDropSource tooltip from the BeginDragDropTarget site.
         ImGuiDragDropFlags_AcceptPeekOnly = ImGuiDragDropFlags_AcceptBeforeDelivery | ImGuiDragDropFlags_AcceptNoDrawDefaultRect
 
     ctypedef enum ImGuiDir_:

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ def extension_sources(path):
             'imgui-cpp/imgui.cpp',
             'imgui-cpp/imgui_draw.cpp',
             'imgui-cpp/imgui_demo.cpp',
+            'imgui-cpp/imgui_widgets.cpp',
             'config-cpp/py_imconfig.cpp'
         ]
 


### PR DESCRIPTION
I went through the API incompatible changes from the patch notes and updated the bindings for 1.65. A few things were deprecated or renamed.

There is also a fix for a typo in the key bindings of KEY_RIGHT_ARROW.