### PR TITLE
Add a link to the actual Python docs at the start of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Builds:
 
 # pyimgui
 
-**pyimgui** is a Cython-based binding for the amazing 
+Python bindings for the amazing
 [dear imgui](https://github.com/ocornut/imgui) C++ library - a Bloat-free
 Immediate Mode Graphical User Interface.
 
+Documentation: [pyimgui.readthedocs.io](https://pyimgui.readthedocs.io/en/latest/index.html)
 
 # Installation
 


### PR DESCRIPTION
Add a direct link to Python library documentation on readthedocs into
the first section of the README.md.  This is the section that many
people see first when they google for pyimgui Python docs, so it's
helpful to link to library user docs right away.

I realize that the readthedocs link is already in the project
description but at least I missed that completely and had to scroll
many pages down to hit the readthedocs link.  This is what many people
looking at the github project will be looking for.

Also drop "Cython-based" as IMO that doesn't help first time readers
of this README.md get an idea of what this project is about.  IMO
"python bindings for ImGui" is more direct and informative.