### PR TITLE
Fix/improved integrations and context warnings

### DIFF
--- a/doc/examples/integrations_all_in_one.py
+++ b/doc/examples/integrations_all_in_one.py
@@ -167,7 +167,7 @@ def main_cocos2d():
             gl.glClearColor(1., 1., 1., 1)
             gl.glClear(gl.GL_COLOR_BUFFER_BIT)
             imgui.render()
-    
+
     director.init(width=800, height=600, resizable=True)
     hello_layer = HelloWorld()
     main_scene = cocos.scene.Scene(hello_layer)
@@ -193,6 +193,9 @@ def on_frame():
 
 
 if __name__ == "__main__":
+    imgui.create_context()
+    io = imgui.get_io()
+
     if backend == "sdl2":
         main_sdl2()
     elif backend == "pygame":

--- a/doc/examples/integrations_cocos2d.py
+++ b/doc/examples/integrations_cocos2d.py
@@ -43,10 +43,12 @@ class HelloWorld(ImguiLayer):
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
 
         imgui.render()
+        self.renderer.render(imgui.get_draw_data())
 
 
 def main():
     director.init(width=800, height=600, resizable=True)
+    imgui.create_context()
 
     hello_layer = HelloWorld()
     main_scene = cocos.scene.Scene(hello_layer)

--- a/doc/examples/integrations_cocos2d.py
+++ b/doc/examples/integrations_cocos2d.py
@@ -48,9 +48,10 @@ class HelloWorld(ImguiLayer):
 
 def main():
     director.init(width=800, height=600, resizable=True)
-    imgui.create_context()
 
+    imgui.create_context()
     hello_layer = HelloWorld()
+
     main_scene = cocos.scene.Scene(hello_layer)
     director.run(main_scene)
 

--- a/doc/examples/integrations_glfw3.py
+++ b/doc/examples/integrations_glfw3.py
@@ -7,6 +7,7 @@ from imgui.integrations.glfw import GlfwRenderer
 
 
 def main():
+    imgui.create_context()
     window = impl_glfw_init()
     impl = GlfwRenderer(window)
 

--- a/doc/examples/integrations_pygame.py
+++ b/doc/examples/integrations_pygame.py
@@ -11,23 +11,22 @@ import imgui
 
 def main():
     pygame.init()
-
     size = 800, 600
 
     pygame.display.set_mode(size, pygame.DOUBLEBUF | pygame.OPENGL)
 
-    io = imgui.get_io()
-    io.fonts.add_font_default()
-    io.display_size = size
+    imgui.create_context()
+    impl = PygameRenderer()
 
-    renderer = PygameRenderer()
+    io = imgui.get_io()
+    io.display_size = size
 
     while 1:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 sys.exit()
 
-            renderer.process_event(event)
+            impl.process_event(event)
 
         imgui.new_frame()
 
@@ -56,8 +55,10 @@ def main():
         gl.glClearColor(1, 1, 1, 1)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
         imgui.render()
+        impl.render(imgui.get_draw_data())
 
         pygame.display.flip()
+
 
 if __name__ == "__main__":
     main()

--- a/doc/examples/integrations_pyglet.py
+++ b/doc/examples/integrations_pyglet.py
@@ -12,7 +12,8 @@ def main():
 
     window = pyglet.window.Window(width=1280, height=720, resizable=True)
     gl.glClearColor(1, 1, 1, 1)
-    renderer = PygletRenderer(window)
+    imgui.create_context()
+    impl = PygletRenderer(window)
 
     def update(dt):
         imgui.new_frame()
@@ -41,10 +42,10 @@ def main():
         update(1/60.0)
         window.clear()
         imgui.render()
-        renderer.render(imgui.get_draw_data())
+        impl.render(imgui.get_draw_data())
 
     pyglet.app.run()
-    renderer.shutdown()
+    impl.shutdown()
 
 
 if __name__ == "__main__":

--- a/doc/examples/integrations_pysdl2.py
+++ b/doc/examples/integrations_pysdl2.py
@@ -9,7 +9,8 @@ from imgui.integrations.sdl2 import SDL2Renderer
 
 def main():
     window, gl_context = impl_pysdl2_init()
-    renderer = SDL2Renderer(window)
+    imgui.create_context()
+    impl = SDL2Renderer(window)
 
     running = True
     event = SDL_Event()
@@ -18,8 +19,8 @@ def main():
             if event.type == SDL_QUIT:
                 running = False
                 break
-            renderer.process_event(event)
-        renderer.process_inputs()
+            impl.process_event(event)
+        impl.process_inputs()
 
         imgui.new_frame()
 
@@ -47,10 +48,10 @@ def main():
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
 
         imgui.render()
-
+        impl.render(imgui.get_draw_data())
         SDL_GL_SwapWindow(window)
 
-    renderer.shutdown()
+    impl.shutdown()
     SDL_GL_DeleteContext(gl_context)
     SDL_DestroyWindow(window)
     SDL_Quit()
@@ -98,6 +99,7 @@ def impl_pysdl2_init():
         exit(1)
 
     return window, gl_context
+
 
 if __name__ == "__main__":
     main()

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -316,9 +316,15 @@ cdef class _ImGuiContext(object):
 
     @staticmethod
     cdef from_ptr(cimgui.ImGuiContext* ptr):
+        if ptr == NULL:
+            return None
+
         instance = _ImGuiContext()
         instance._ptr = ptr
         return instance
+
+    def __eq__(_ImGuiContext self, _ImGuiContext other):
+        return other._ptr == self._ptr
 
 
 cdef class _DrawCmd(object):
@@ -328,6 +334,9 @@ cdef class _DrawCmd(object):
     #       see: http://cython.readthedocs.io/en/latest/src/userguide/extension_types.html#fast-instantiation
     @staticmethod
     cdef from_ptr(cimgui.ImDrawCmd* ptr):
+        if ptr == NULL:
+            return None
+
         instance = _DrawCmd()
         instance._ptr = ptr
         return instance
@@ -350,6 +359,9 @@ cdef class _DrawList(object):
 
     @staticmethod
     cdef from_ptr(cimgui.ImDrawList* ptr):
+        if ptr == NULL:
+            return None
+
         instance = _DrawList()
         instance._ptr = ptr
         return instance
@@ -799,6 +811,9 @@ cdef class _DrawData(object):
 
     @staticmethod
     cdef from_ptr(cimgui.ImDrawData* ptr):
+        if ptr == NULL:
+            return None
+
         instance = _DrawData()
         instance._ptr = ptr
         return instance
@@ -845,6 +860,9 @@ cdef class _StaticGlyphRanges(object):
 
     @staticmethod
     cdef from_ptr(const cimgui.ImWchar* ptr):
+        if ptr == NULL:
+            return None
+
         instance = _StaticGlyphRanges()
         instance.ranges_ptr = ptr
         return instance
@@ -853,6 +871,9 @@ cdef class _StaticGlyphRanges(object):
 cdef class _Font(object):
     @staticmethod
     cdef from_ptr(cimgui.ImFont* ptr):
+        if ptr == NULL:
+            return None
+
         instance = _Font()
         instance._ptr = ptr
         return instance
@@ -880,6 +901,9 @@ cdef class _FontAtlas(object):
 
     @staticmethod
     cdef from_ptr(cimgui.ImFontAtlas* ptr):
+        if ptr == NULL:
+            return None
+
         instance = _FontAtlas()
         instance._ptr = ptr
         return instance
@@ -6431,7 +6455,7 @@ def get_frame_height():
 
     .. wraps::
         float GetFrameHeight()
-    float GetFrameHeightWithSpacing() except +  # ✗
+    float GetFrameHeightWithSpacing() except +
     """
     return cimgui.GetFrameHeight()
 
@@ -6477,11 +6501,11 @@ def destroy_context(_ImGuiContext ctx = None):
                 ImGuiContext* ctx = NULL);
     """
 
-    if ctx:
+    if ctx and ctx._ptr != NULL:
         cimgui.DestroyContext(ctx._ptr)
+        ctx._ptr = NULL
     else:
-        cimgui.DestroyContext(NULL)
-
+        raise RuntimeError("Context invalid (None or destroyed)")
 
 
 def get_current_context():

--- a/imgui/integrations/__init__.py
+++ b/imgui/integrations/__init__.py
@@ -1,20 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from warnings import warn
-
-
-warn(
-    """
-    Integration layer in imgui.integrations is still in experimental mode.
-    Expect major changes in future versions. For safety it is recommended
-    to use code vendoring for specific integration impementation.
-
-    This subpackage should become stable in 1.0.0 version.
-
-    """, FutureWarning
-)
-
 
 def compute_fb_scale(window_size, frame_buffer_size):
     win_width, win_height = window_size

--- a/imgui/integrations/__init__.py
+++ b/imgui/integrations/__init__.py
@@ -14,3 +14,14 @@ warn(
 
     """, FutureWarning
 )
+
+
+def compute_fb_scale(window_size, frame_buffer_size):
+    win_width, win_height = window_size
+    fb_width, fb_height = frame_buffer_size
+
+    # future: remove floats after dropping py27 support
+    if win_width != 0 and win_width != 0:
+        return float(fb_width) / win_width, float(fb_height) / win_height
+
+    return 1., 1.

--- a/imgui/integrations/cocos2d.py
+++ b/imgui/integrations/cocos2d.py
@@ -14,14 +14,6 @@ class ImguiLayer(PygletMixin, cocos.layer.Layer):
     def __init__(self):
         super(ImguiLayer, self).__init__()
 
-        self.renderer = None
+        self.renderer = FixedPipelineRenderer()
         self.io = imgui.get_io()
-
         self._map_keys()
-
-    def on_enter(self):
-        super(ImguiLayer, self).on_enter()
-
-        if self.renderer is None:
-            self.io.display_size = cocos.director.director.get_window_size()
-            self.renderer = FixedPipelineRenderer()

--- a/imgui/integrations/cocos2d.py
+++ b/imgui/integrations/cocos2d.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 import cocos
 
 import imgui
+
+from .import compute_fb_scale
 from .pyglet import PygletMixin
 from .opengl import FixedPipelineRenderer
 
@@ -14,6 +16,12 @@ class ImguiLayer(PygletMixin, cocos.layer.Layer):
     def __init__(self):
         super(ImguiLayer, self).__init__()
 
-        self.renderer = FixedPipelineRenderer()
+        window_size = cocos.director.director.window.get_size()
+        viewport_size = cocos.director.director.window.get_viewport_size()
+
         self.io = imgui.get_io()
+        self.io.display_size = window_size
+        self.io.display_fb_scale = compute_fb_scale(window_size, viewport_size)
+
+        self.renderer = FixedPipelineRenderer()
         self._map_keys()

--- a/imgui/integrations/glfw.py
+++ b/imgui/integrations/glfw.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import glfw
 import imgui
 
+from . import compute_fb_scale
 from .opengl import ProgrammablePipelineRenderer
 
 
@@ -92,16 +93,13 @@ class GlfwRenderer(ProgrammablePipelineRenderer):
         self.io.mouse_wheel = y_offset
 
     def process_inputs(self):
-        # todo: consider moving to init
         io = imgui.get_io()
 
-        w, h = glfw.get_window_size(self.window)
-        dw, dh = glfw.get_framebuffer_size(self.window)
+        window_size = glfw.get_window_size(self.window)
+        fb_size = glfw.get_framebuffer_size(self.window)
 
-        io.display_size = w, h
-        if w != 0 and h != 0:
-            io.display_fb_scale = float(dw)/w, float(dh)/h # else?
-
+        io.display_size = window_size
+        io.display_fb_scale = compute_fb_scale(window_size, fb_size)
         io.delta_time = 1.0/60
 
         if glfw.get_window_attrib(self.window, glfw.FOCUSED):

--- a/imgui/integrations/opengl.py
+++ b/imgui/integrations/opengl.py
@@ -9,7 +9,11 @@ import ctypes
 
 class BaseOpenGLRenderer(object):
     def __init__(self):
-        imgui.create_context()
+        if not imgui.get_current_context():
+            raise RuntimeError(
+                "No valid ImGui context. Use imgui.create_context() first and/or "
+                "imgui.set_current_context()."
+            )
         self.io = imgui.get_io()
 
         self._font_texture = None
@@ -18,9 +22,6 @@ class BaseOpenGLRenderer(object):
 
         self._create_device_objects()
         self.refresh_font_texture()
-
-        # todo: add option to set new_frame callback/implementation
-        #self.io.render_callback = self.render
 
     def render(self, draw_data):
         raise NotImplementedError
@@ -36,7 +37,6 @@ class BaseOpenGLRenderer(object):
 
     def shutdown(self):
         self._invalidate_device_objects()
-        imgui.destroy_context()
 
 
 class ProgrammablePipelineRenderer(BaseOpenGLRenderer):

--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -5,6 +5,7 @@ from pyglet.window import key, mouse
 
 import imgui
 
+from . import compute_fb_scale
 from .opengl import FixedPipelineRenderer
 
 
@@ -102,7 +103,12 @@ class PygletMixin(object):
 class PygletRenderer(PygletMixin, FixedPipelineRenderer):
     def __init__(self, window, attach_callbacks=True):
         super(PygletRenderer, self).__init__()
-        self.io.display_size = window.width, window.height
+        window_size = window.get_size()
+        viewport_size = window.get_viewport_size()
+
+        self.io.display_size = window_size
+        self.io.display_fb_scale = compute_fb_scale(window_size, viewport_size)
+
         self._map_keys()
 
         if attach_callbacks:

--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -106,12 +106,14 @@ class PygletRenderer(PygletMixin, FixedPipelineRenderer):
         self._map_keys()
 
         if attach_callbacks:
-            window.push_handlers(self.on_mouse_motion,
-                                 self.on_key_press,
-                                 self.on_key_release,
-                                 self.on_text,
-                                 self.on_mouse_drag,
-                                 self.on_mouse_press,
-                                 self.on_mouse_release,
-                                 self.on_mouse_scroll,
-                                 self.on_resize)
+            window.push_handlers(
+                self.on_mouse_motion,
+                self.on_key_press,
+                self.on_key_release,
+                self.on_text,
+                self.on_mouse_drag,
+                self.on_mouse_press,
+                self.on_mouse_release,
+                self.on_mouse_scroll,
+                self.on_resize,
+            )

--- a/tests/test_context_mem_safety.py
+++ b/tests/test_context_mem_safety.py
@@ -1,0 +1,52 @@
+"""Note: This tests are potential crashers (may result in segfaults)"""
+import pytest
+
+import imgui
+
+
+@pytest.fixture()
+def no_context():
+    ctx = imgui.get_current_context()
+    if ctx is not None:
+        imgui.destroy_context(ctx)
+
+
+def test_get_current_context_no_context(no_context):
+    assert imgui.get_current_context() is None
+
+
+def test_create_context_no_context(no_context):
+    ctx = imgui.create_context()
+    assert ctx is not None
+    assert imgui.get_current_context() is not None
+
+
+def test_create_context_ctx_object_identity(no_context):
+    ctx = imgui.create_context()
+    assert ctx is not None
+    assert ctx == imgui.get_current_context()
+
+
+def test_destroy_empty_context(no_context):
+    with pytest.raises(RuntimeError):
+        imgui.destroy_context()
+
+
+def test_destroy_destroyed_context(no_context):
+    ctx = imgui.create_context()
+    assert ctx is not None
+
+    imgui.destroy_context(ctx)
+
+    with pytest.raises(RuntimeError):
+        imgui.destroy_context(ctx)
+
+
+def test_set_current_context_destroyed(no_context):
+    ctx = imgui.create_context()
+    assert ctx is not None
+
+    imgui.destroy_context(ctx)
+
+    imgui.set_current_context(ctx)
+    assert imgui.get_current_context() is None


### PR DESCRIPTION
- added some ifs for context functions handling to avoid segmentations faults
- added __eq__ handler to context pointer wrapper class to allow comparing context objects
- added tests for contexts
- now user needs to create his own context when working with integrations
- removed warning for experimental integrations, closes #109 
- fixed integration examples, closes #104 
- fixed framebuffer scaling issue on high-density screens (macOS)
- added warning to integrations that context needs to be created

Notes: cocos2d and pyglet examples crashes on window resize, this is wontfix as there is an error directly in pyglet. 