### PR TITLE
gettable/settable GuiStyle colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ commands:
 
 
 # Development tips
-We have tried hard to make the process of bootstraping this project as simple
+We have tried hard to make the process of bootstrapping this project as simple
 as possible.
 
 In order to build and install project locally ,ake sure you have created and

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -562,12 +562,12 @@ cdef class GuiStyle(object):
     """
     cdef cimgui.ImGuiStyle* _ptr
     cdef bool _owner
-    cdef public Colors colors
+    cdef Colors _colors
 
     def __cinit__(self):
         self._ptr = NULL
         self._owner = False
-        self.colors = None
+        self._colors = None
 
     def __dealloc__(self):
         if self._owner:
@@ -593,7 +593,7 @@ cdef class GuiStyle(object):
     cdef GuiStyle from_ref(cimgui.ImGuiStyle& ref):
         cdef GuiStyle instance = GuiStyle()
         instance._ptr = &ref
-        instance.colors = Colors(instance)
+        instance._colors = Colors(instance)
         return instance
 
     @staticmethod
@@ -601,7 +601,7 @@ cdef class GuiStyle(object):
         cdef cimgui.ImGuiStyle* _ptr = new cimgui.ImGuiStyle()
         cdef GuiStyle instance = GuiStyle.from_ref(deref(_ptr))
         instance._owner = True
-        instance.colors = Colors(instance)
+        instance._colors = Colors(instance)
         return instance
 
     @property
@@ -906,6 +906,11 @@ cdef class GuiStyle(object):
         self._check_ptr()
         cdef int ix = variable
         return _cast_ImVec4_tuple(self._ptr.Colors[ix])
+
+    @property
+    def colors(self):
+        self._check_ptr()
+        return self._colors
 
 
 cdef class _DrawData(object):

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -529,7 +529,7 @@ cdef class _DrawList(object):
             for idx in xrange(self._ptr.CmdBuffer.Size)
         ]
 
-cdef class Color(object):
+cdef class Colors(object):
     cdef GuiStyle _style
 
     def __cinit__(self):
@@ -562,12 +562,12 @@ cdef class GuiStyle(object):
     """
     cdef cimgui.ImGuiStyle* _ptr
     cdef bool _owner
-    cdef public Color color
+    cdef public Colors colors
 
     def __cinit__(self):
         self._ptr = NULL
         self._owner = False
-        self.color = None
+        self.colors = None
 
     def __dealloc__(self):
         if self._owner:
@@ -593,7 +593,7 @@ cdef class GuiStyle(object):
     cdef GuiStyle from_ref(cimgui.ImGuiStyle& ref):
         cdef GuiStyle instance = GuiStyle()
         instance._ptr = &ref
-        instance.color = Color(instance)
+        instance.colors = Colors(instance)
         return instance
 
     @staticmethod
@@ -601,7 +601,7 @@ cdef class GuiStyle(object):
         cdef cimgui.ImGuiStyle* _ptr = new cimgui.ImGuiStyle()
         cdef GuiStyle instance = GuiStyle.from_ref(deref(_ptr))
         instance._owner = True
-        instance.color = Color(instance)
+        instance.colors = Colors(instance)
         return instance
 
     @property

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -529,7 +529,7 @@ cdef class _DrawList(object):
             for idx in xrange(self._ptr.CmdBuffer.Size)
         ]
 
-cdef class Colors(object):
+cdef class _Colors(object):
     cdef GuiStyle _style
 
     def __cinit__(self):
@@ -562,7 +562,7 @@ cdef class GuiStyle(object):
     """
     cdef cimgui.ImGuiStyle* _ptr
     cdef bool _owner
-    cdef Colors _colors
+    cdef _Colors _colors
 
     def __cinit__(self):
         self._ptr = NULL
@@ -593,7 +593,7 @@ cdef class GuiStyle(object):
     cdef GuiStyle from_ref(cimgui.ImGuiStyle& ref):
         cdef GuiStyle instance = GuiStyle()
         instance._ptr = &ref
-        instance._colors = Colors(instance)
+        instance._colors = _Colors(instance)
         return instance
 
     @staticmethod
@@ -601,7 +601,7 @@ cdef class GuiStyle(object):
         cdef cimgui.ImGuiStyle* _ptr = new cimgui.ImGuiStyle()
         cdef GuiStyle instance = GuiStyle.from_ref(deref(_ptr))
         instance._owner = True
-        instance._colors = Colors(instance)
+        instance._colors = _Colors(instance)
         return instance
 
     @property
@@ -909,6 +909,23 @@ cdef class GuiStyle(object):
 
     @property
     def colors(self):
+        """Retrieve and modify style colors through list-like interface.
+
+        .. visual-example::
+            :width: 700
+            :height: 500
+            :auto_layout:
+
+            style = imgui.get_style()
+            imgui.begin("Color window")
+            imgui.columns(4)
+            for color in range(0, imgui.COLOR_COUNT):
+                imgui.text("Color: {}".format(color))
+                imgui.color_button("color#{}".format(color), *style.colors[color])
+                imgui.next_column()
+
+            imgui.end()
+        """
         self._check_ptr()
         return self._colors
 

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -899,6 +899,14 @@ cdef class GuiStyle(object):
         self._check_ptr()
         self._ptr.CurveTessellationTol = value
 
+    def color(self, cimgui.ImGuiCol variable):
+        if not (0 <= variable < enums.ImGuiCol_COUNT):
+            raise ValueError("Unknown style variable: {}".format(variable))
+
+        self._check_ptr()
+        cdef int ix = variable
+        return _cast_ImVec4_tuple(self._ptr.Colors[ix])
+
 
 cdef class _DrawData(object):
     cdef cimgui.ImDrawData* _ptr

--- a/tests/test_gui_style_initialization.py
+++ b/tests/test_gui_style_initialization.py
@@ -18,6 +18,8 @@ def context():
 
 @pytest.fixture(params=IMGUI_DATA_DESCRIPTORS)
 def data_descriptor(request):
+    if request.param == "colors":
+        pytest.skip("'{}' isn't a writable property".format(request.param))
     return request.param
 
 


### PR DESCRIPTION
This allows getting and setting colors for `GuiStyle`. Currently, I think `GuiStyle` only allows for retrieving values (not setting them). It changes the API a bit:

```python
# getters
# master
val = style.color(imgui.COLOR_BUTTON)
# branch
val = stye.color[imgui.COLOR_BUTTON]

# setter (branch only)
style.color[imgui.COLOR_BUTTON] = (0.1, 0.6, 0.1, 1)
```

This is my first foray into cython, so the implementation might not be quite right...

For example, here's the pyglet example + style tweaks:

```python
import pyglet
from pyglet import gl

import imgui
from imgui.integrations.pyglet import PygletRenderer

def main():
    window = pyglet.window.Window(width=1280, height=720, resizable=True)
    gl.glClearColor(1, 1, 1, 1)
    imgui.create_context()
    impl = PygletRenderer(window)
    # modify the current style
    style = imgui.get_style()
    print(style.color[imgui.COLOR_BORDER])
    style.color[imgui.COLOR_TITLE_BACKGROUND] = (0.9, 0.2, 0.2, 0.9)
    style.color[imgui.COLOR_WINDOW_BACKGROUND] = [0.5]*4
    style.frame_rounding = 14

    def update(dt):
        imgui.new_frame()
        if imgui.begin_main_menu_bar():
            if imgui.begin_menu("File", True):
                clicked_quit, selected_quit = imgui.menu_item(
                    "Quit", 'Cmd+Q', False, True
                )
                if clicked_quit:
                    exit(1)

                imgui.end_menu()
            imgui.end_main_menu_bar()

        imgui.show_test_window()

        imgui.begin("Custom window", True)
        imgui.text("Bar")
        imgui.text_colored("Eggs", 0.2, 1., 0.)
        imgui.end()

    @window.event
    def on_draw():
        update(1/60.0)
        window.clear()
        imgui.render()
        impl.render(imgui.get_draw_data())

    pyglet.app.run()
    impl.shutdown()

if __name__ == "__main__":
    main()


```