### PR TITLE
Adding initial cyglfw3 integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ want to install all additional dependencies you can always use bare
 
 * for pygame backend use `pip install imgui[pygame]`
 * for GLFW3 backend use `pip install imgui[glfw]`
+* for cyglfw3 backend use `pip install imgui[cyglfw3]`
 * for SDL2 backend use `pip install imgui[sdl2]`
 * for Cocos2d backend use `pip install imgui[cocos2d]`
 * for pyglet backend use `pip install imgui[pyglet]`

--- a/doc/examples/integrations_cyglfw3.py
+++ b/doc/examples/integrations_cyglfw3.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+import cyglfw3
+import OpenGL.GL as gl
+
+import imgui
+from imgui.integrations.cyglfw3 import Cyglfw3Renderer
+
+
+def main():
+    imgui.create_context()
+    window = impl_glfw_init()
+    impl = Cyglfw3Renderer(window)
+
+    while not cyglfw3.WindowShouldClose(window):
+        cyglfw3.PollEvents()
+        impl.process_inputs()
+
+        imgui.new_frame()
+
+        if imgui.begin_main_menu_bar():
+            if imgui.begin_menu("File", True):
+
+                clicked_quit, selected_quit = imgui.menu_item(
+                    "Quit", 'Cmd+Q', False, True
+                )
+
+                if clicked_quit:
+                    exit(1)
+
+                imgui.end_menu()
+            imgui.end_main_menu_bar()
+
+        imgui.show_test_window()
+
+        imgui.begin("Custom window", True)
+        imgui.text("Bar")
+        imgui.text_colored("Eggs", 0.2, 1., 0.)
+        imgui.end()
+
+        gl.glClearColor(1., 1., 1., 1)
+        gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+        imgui.render()
+        impl.render(imgui.get_draw_data())
+        cyglfw3.SwapBuffers(window)
+
+    impl.shutdown()
+    cyglfw3.Terminate()
+
+
+def impl_glfw_init():
+    width, height = 1280, 720
+    window_name = "minimal ImGui/GLFW3 example"
+
+    if not cyglfw3.Init():
+        print("Could not initialize OpenGL context")
+        exit(1)
+
+    # OS X supports only forward-compatible core profiles from 3.2
+    cyglfw3.WindowHint(cyglfw3.CONTEXT_VERSION_MAJOR, 3)
+    cyglfw3.WindowHint(cyglfw3.CONTEXT_VERSION_MINOR, 3)
+    cyglfw3.WindowHint(cyglfw3.OPENGL_PROFILE, cyglfw3.OPENGL_CORE_PROFILE)
+
+    cyglfw3.WindowHint(cyglfw3.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
+
+    # Create a windowed mode window and its OpenGL context
+    window = cyglfw3.CreateWindow(
+        int(width), int(height), window_name, None, None
+    )
+    cyglfw3.MakeContextCurrent(window)
+
+    if not window:
+        cyglfw3.Terminate()
+        print("Could not initialize Window")
+        exit(1)
+
+    return window
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -450,4 +450,4 @@ napoleon_use_rtype = False
 
 autodoc_member_order = 'bysource'
 # this is in order to support GlfwImpl documentation on RTD
-autodoc_mock_imports = ['cocos', 'glfw',  'OpenGL', 'pygame', 'pyglet', 'sdl2']
+autodoc_mock_imports = ['cocos', 'glfw', 'cyglfw3', 'OpenGL', 'pygame', 'pyglet', 'sdl2']

--- a/doc/source/guide/first-steps.rst
+++ b/doc/source/guide/first-steps.rst
@@ -110,6 +110,10 @@ and libraries:
   windowing library through
   `glfw Python package <https://pypi.python.org/pypi/glfw>`_
   .
+* :mod:`imgui.integrations.cyglfw3` integrates **pyimgui** with GLFW_ OpenGL
+  windowing library through the Cython GLFW wrapper
+  `cyglfw3 Python package <https://pypi.python.org/pypi/cyglfw3>`_
+  .
 * :mod:`imgui.integrations.pygame` integrates **pyimgui** with pygame_ game
   engine.
 * :mod:`imgui.integrations.sdl2` integrates **pyimgui** with SDL2_ library

--- a/doc/source/reference/imgui.integrations.rst
+++ b/doc/source/reference/imgui.integrations.rst
@@ -19,6 +19,13 @@ imgui.integrations.glfw module
     :undoc-members:
     :members:
 
+imgui.integrations.cyglfw3 module
+------------------------------
+
+.. automodule:: imgui.integrations.cyglfw3
+    :undoc-members:
+    :members:
+
 imgui.integrations.opengl module
 --------------------------------
 

--- a/imgui/integrations/cyglfw3.py
+++ b/imgui/integrations/cyglfw3.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import cyglfw3
+import imgui
+
+from . import compute_fb_scale
+from .opengl import ProgrammablePipelineRenderer
+
+
+class Cyglfw3Renderer(ProgrammablePipelineRenderer):
+    def __init__(self, window, attach_callbacks=True):
+        super(Cyglfw3Renderer, self).__init__()
+        self.window = window
+
+        if attach_callbacks:
+            cyglfw3.SetKeyCallback(self.window, self.keyboard_callback)
+            cyglfw3.SetCursorPosCallback(self.window, self.mouse_callback)
+            cyglfw3.SetWindowSizeCallback(self.window, self.resize_callback)
+            cyglfw3.SetCharCallback(self.window, self.char_callback)
+            cyglfw3.SetScrollCallback(self.window, self.scroll_callback)
+
+        self.io.display_size = cyglfw3.GetFramebufferSize(self.window)
+
+        self._map_keys()
+        self._gui_time = None
+
+    def _map_keys(self):
+        key_map = self.io.key_map
+
+        key_map[imgui.KEY_TAB] = cyglfw3.KEY_TAB
+        key_map[imgui.KEY_LEFT_ARROW] = cyglfw3.KEY_LEFT
+        key_map[imgui.KEY_RIGHT_ARROW] = cyglfw3.KEY_RIGHT
+        key_map[imgui.KEY_UP_ARROW] = cyglfw3.KEY_UP
+        key_map[imgui.KEY_DOWN_ARROW] = cyglfw3.KEY_DOWN
+        key_map[imgui.KEY_PAGE_UP] = cyglfw3.KEY_PAGE_UP
+        key_map[imgui.KEY_PAGE_DOWN] = cyglfw3.KEY_PAGE_DOWN
+        key_map[imgui.KEY_HOME] = cyglfw3.KEY_HOME
+        key_map[imgui.KEY_END] = cyglfw3.KEY_END
+        key_map[imgui.KEY_DELETE] = cyglfw3.KEY_DELETE
+        key_map[imgui.KEY_BACKSPACE] = cyglfw3.KEY_BACKSPACE
+        key_map[imgui.KEY_ENTER] = cyglfw3.KEY_ENTER
+        key_map[imgui.KEY_ESCAPE] = cyglfw3.KEY_ESCAPE
+        key_map[imgui.KEY_A] = cyglfw3.KEY_A
+        key_map[imgui.KEY_C] = cyglfw3.KEY_C
+        key_map[imgui.KEY_V] = cyglfw3.KEY_V
+        key_map[imgui.KEY_X] = cyglfw3.KEY_X
+        key_map[imgui.KEY_Y] = cyglfw3.KEY_Y
+        key_map[imgui.KEY_Z] = cyglfw3.KEY_Z
+
+    def keyboard_callback(self, window, key, scancode, action, mods):
+        # perf: local for faster access
+        io = self.io
+
+        if action == cyglfw3.PRESS:
+            io.keys_down[key] = True
+        elif action == cyglfw3.RELEASE:
+            io.keys_down[key] = False
+
+        io.key_ctrl = (
+            io.keys_down[cyglfw3.KEY_LEFT_CONTROL] or
+            io.keys_down[cyglfw3.KEY_RIGHT_CONTROL]
+        )
+
+        io.key_alt = (
+            io.keys_down[cyglfw3.KEY_LEFT_ALT] or
+            io.keys_down[cyglfw3.KEY_RIGHT_ALT]
+        )
+
+        io.key_shift = (
+            io.keys_down[cyglfw3.KEY_LEFT_SHIFT] or
+            io.keys_down[cyglfw3.KEY_RIGHT_SHIFT]
+        )
+
+    def char_callback(self, window, char):
+        io = imgui.get_io()
+
+        if 0 < char < 0x10000:
+            io.add_input_character(char)
+
+    def resize_callback(self, window, width, height):
+        self.io.display_size = width, height
+
+    def mouse_callback(self, *args, **kwargs):
+        pass
+
+    def scroll_callback(self, window, x_offset, y_offset):
+        self.io.mouse_wheel = y_offset
+
+    def process_inputs(self):
+        io = imgui.get_io()
+
+        window_size = cyglfw3.GetWindowSize(self.window)
+        fb_size = cyglfw3.GetFramebufferSize(self.window)
+
+        io.display_size = window_size
+        io.display_fb_scale = compute_fb_scale(window_size, fb_size)
+        io.delta_time = 1.0/60
+
+        if cyglfw3.GetWindowAttrib(self.window, cyglfw3.FOCUSED):
+            io.mouse_pos = cyglfw3.GetCursorPos(self.window)
+        else:
+            io.mouse_pos = -1, -1
+
+        io.mouse_down[0] = cyglfw3.GetMouseButton(self.window, 0)
+        io.mouse_down[1] = cyglfw3.GetMouseButton(self.window, 1)
+        io.mouse_down[2] = cyglfw3.GetMouseButton(self.window, 2)
+
+        current_time = cyglfw3.GetTime()
+
+        if self._gui_time:
+            self.io.delta_time = current_time - self._gui_time
+        else:
+            self.io.delta_time = 1. / 60.
+
+        self._gui_time = current_time

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ EXTRAS_REQUIRE = {
     'cocos2d': backend_extras('cocos2d'),
     'sdl2': backend_extras('PySDL2'),
     'glfw': backend_extras('glfw'),
+    'cyglfw3': backend_extras('cyglfw3'),
     'pygame': backend_extras('pygame'),
     'opengl': backend_extras(),
     'pyglet': backend_extras('pyglet')


### PR DESCRIPTION
This adds support for using [cyglfw3](https://pypi.org/project/cyglfw3/) as an interface to glfw.  It is almost completely a 1:1 mapping of the glfw integration, but switching to cased words without underscores.