### PR TITLE
Fix assertion error

### DIFF
--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -21,6 +21,7 @@ class PygletMixin(object):
         key.HOME: imgui.KEY_HOME,
         key.END: imgui.KEY_END,
         key.DELETE: imgui.KEY_DELETE,
+        key.SPACE: imgui.KEY_SPACE,
         key.BACKSPACE: imgui.KEY_BACKSPACE,
         key.RETURN: imgui.KEY_ENTER,
         key.ESCAPE: imgui.KEY_ESCAPE,


### PR DESCRIPTION
imgui.core.ImGuiError: ImGui assertion error (g.IO.KeyMap[ImGuiKey_Space] != -1 && "ImGuiKey_Space is not mapped, required for keyboard navigation.") at imgui-cpp/imgui.cpp:3101

Error was thrown after enabling keyboard navigation because of the missing 'space' key in REVERSE_KEY_MAP