### PR TITLE
Add support for ImGuiIO clipboard callbacks

### DIFF
--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -113,8 +113,9 @@ cdef extern from "imgui.h":
         # source-note: User Functions
         # note: callbacks may wrap arbitrary Python code so we need to
         #       propagate exceptions from them (as well as C++ exceptions)
-        const char* (*GetClipboardTextFn)() except +  # ✗
-        void        (*SetClipboardTextFn)(const char* text) except +  # ✗
+        const char* (*GetClipboardTextFn)(void* user_data) except +  # ✓
+        void        (*SetClipboardTextFn)(void* user_data, const char* text) except +  # ✓
+        void*       ClipboardUserData  # ✗
 
         void*       (*MemAllocFn)(size_t sz) except +  # ✗
         void        (*MemFreeFn)(void* ptr) except +  # ✗

--- a/imgui/integrations/glfw.py
+++ b/imgui/integrations/glfw.py
@@ -21,9 +21,17 @@ class GlfwRenderer(ProgrammablePipelineRenderer):
             glfw.set_scroll_callback(self.window, self.scroll_callback)
 
         self.io.display_size = glfw.get_framebuffer_size(self.window)
+        self.io.get_clipboard_text_fn = self._get_clipboard_text
+        self.io.set_clipboard_text_fn = self._set_clipboard_text
 
         self._map_keys()
         self._gui_time = None
+
+    def _get_clipboard_text(self):
+        return glfw.get_clipboard_string(self.window)
+
+    def _set_clipboard_text(self, text):
+        glfw.set_clipboard_string(self.window, text)
 
     def _map_keys(self):
         key_map = self.io.key_map

--- a/imgui/integrations/sdl2.py
+++ b/imgui/integrations/sdl2.py
@@ -26,8 +26,16 @@ class SDL2Renderer(ProgrammablePipelineRenderer):
         SDL_GetWindowSize(self.window, width_ptr, height_ptr)
 
         self.io.display_size = width_ptr[0], height_ptr[0]
+        self.io.get_clipboard_text_fn = self._get_clipboard_text
+        self.io.set_clipboard_text_fn = self._set_clipboard_text
 
         self._map_keys()
+
+    def _get_clipboard_text(self):
+        return SDL_GetClipboardText()
+
+    def _set_clipboard_text(self, text):
+        SDL_SetClipboardText(text)
 
     def _map_keys(self):
         key_map = self.io.key_map


### PR DESCRIPTION
Allows user/system clipboard integration (aside from the internal ImGui clipboard and the out-of-the-box supported Windows clipboard).
System clipboard is enabled in GLFW integration.