### PR TITLE
Move BaseOpenGLRenderer into a separate module

### DIFF
--- a/imgui/integrations/base.py
+++ b/imgui/integrations/base.py
@@ -1,0 +1,33 @@
+import imgui
+
+
+class BaseOpenGLRenderer(object):
+    def __init__(self):
+        if not imgui.get_current_context():
+            raise RuntimeError(
+                "No valid ImGui context. Use imgui.create_context() first and/or "
+                "imgui.set_current_context()."
+            )
+        self.io = imgui.get_io()
+
+        self._font_texture = None
+
+        self.io.delta_time = 1.0 / 60.0
+
+        self._create_device_objects()
+        self.refresh_font_texture()
+
+    def render(self, draw_data):
+        raise NotImplementedError
+
+    def refresh_font_texture(self):
+        raise NotImplementedError
+
+    def _create_device_objects(self):
+        raise NotImplementedError
+
+    def _invalidate_device_objects(self):
+        raise NotImplementedError
+
+    def shutdown(self):
+        self._invalidate_device_objects()

--- a/imgui/integrations/opengl.py
+++ b/imgui/integrations/opengl.py
@@ -2,41 +2,10 @@
 from __future__ import absolute_import
 
 import OpenGL.GL as gl
-
 import imgui
 import ctypes
 
-
-class BaseOpenGLRenderer(object):
-    def __init__(self):
-        if not imgui.get_current_context():
-            raise RuntimeError(
-                "No valid ImGui context. Use imgui.create_context() first and/or "
-                "imgui.set_current_context()."
-            )
-        self.io = imgui.get_io()
-
-        self._font_texture = None
-
-        self.io.delta_time = 1.0 / 60.0
-
-        self._create_device_objects()
-        self.refresh_font_texture()
-
-    def render(self, draw_data):
-        raise NotImplementedError
-
-    def refresh_font_texture(self):
-        raise NotImplementedError
-
-    def _create_device_objects(self):
-        raise NotImplementedError
-
-    def _invalidate_device_objects(self):
-        raise NotImplementedError
-
-    def shutdown(self):
-        self._invalidate_device_objects()
+from .base import BaseOpenGLRenderer
 
 
 class ProgrammablePipelineRenderer(BaseOpenGLRenderer):


### PR DESCRIPTION
This means we can extend the BaseOpenGLRenderer without having depend on PyOpenGL. There are several other wrappers out there.

Moderngl and pyglet are to examples. I have released my moderngl integration, but want it to be out there for a bit longer to iron out the last bugs before I PR it here.