### PR TITLE
add ctrl key support for pyglet integration

### DIFF
--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -47,11 +47,15 @@ class PygletMixin(object):
     def on_key_press(self, key, mods):
         if key in self.REVERSE_KEY_MAP:
             self.io.keys_down[self.REVERSE_KEY_MAP[key]] = True
+        
+        self.io.key_ctrl = mods & pyg_key.MOD_CTRL and True
 
     def on_key_release(self, key, mods):
         if key in self.REVERSE_KEY_MAP:
             self.io.keys_down[self.REVERSE_KEY_MAP[key]] = False
 
+        self.io.key_ctrl = mods & pyg_key.MOD_CTRL and False
+            
     def on_text(self, text):
         io = imgui.get_io()
 


### PR DESCRIPTION
I was trying to use Ctrl-A to highlight the text I was writing in a text_input and this seems to fix it.

I'd bet something similar could be used for alt, shift, and super/windows key but I haven't tested those myself so I didn't want to commit it.