### PR TITLE
enable glumpy interaction

### DIFF
--- a/imgui/integrations/opengl.py
+++ b/imgui/integrations/opengl.py
@@ -173,12 +173,12 @@ class ProgrammablePipelineRenderer(BaseOpenGLRenderer):
 
         gl.glViewport(0, 0, int(fb_width), int(fb_height))
 
-        ortho_projection = [
-            [ 2.0/display_width, 0.0,                   0.0, 0.0],
-            [ 0.0,               2.0/-display_height,   0.0, 0.0],
-            [ 0.0,               0.0,                  -1.0, 0.0],
-            [-1.0,               1.0,                   0.0, 1.0]
-        ]
+        ortho_projection = (ctypes.c_float * 16)( *[
+             2.0/display_width, 0.0,                   0.0, 0.0,
+             0.0,               2.0/-display_height,   0.0, 0.0,
+             0.0,               0.0,                  -1.0, 0.0,
+            -1.0,               1.0,                   0.0, 1.0
+        ]);
 
         gl.glUseProgram(self._shader_handle)
         gl.glUniform1i(self._attrib_location_tex, 0)


### PR DESCRIPTION
Dear authors,

this is a very minor modification that enables the use of imgui with the glumpy library 

https://github.com/glumpy/glumpy/issues/174
https://github.com/glumpy/glumpy/pull/177

The definition of the projection matrix should be a ctypes or numpy array. 
In the current implementation, it leads to an error in baseplatform.py of pyopengl. 
The error is documented in pull request 177 above, comment of 

dan90210 commented on Jan 8, 2019

The submitted change fixes the problem. For the implementation 
I chose ctypes over numpy (as suggested in the thread above) 
because it is already used in opengl.py and only requires a very 
minor change. 

I suppose the problem could also occur in other contexts since it 
regards the interaction of pyimgui and pyopengl.

best regards,

Ivo
 

