### PR TITLE
Switch pyglet to programmable pipeline

### DIFF
--- a/doc/examples/integrations_pyglet.py
+++ b/doc/examples/integrations_pyglet.py
@@ -5,7 +5,10 @@ import pyglet
 from pyglet import gl
 
 import imgui
-from imgui.integrations.pyglet import PygletRenderer
+# Note that we could explicitly choose to use PygletFixedPipelineRenderer
+# or PygletProgrammablePipelineRenderer, but create_renderer handles the
+# version checking for us.
+from imgui.integrations.pyglet import create_renderer
 
 
 def main():
@@ -13,7 +16,7 @@ def main():
     window = pyglet.window.Window(width=1280, height=720, resizable=True)
     gl.glClearColor(1, 1, 1, 1)
     imgui.create_context()
-    impl = PygletRenderer(window)
+    impl = create_renderer(window)
 
     def update(dt):
         imgui.new_frame()

--- a/doc/source/guide/first-steps.rst
+++ b/doc/source/guide/first-steps.rst
@@ -114,7 +114,9 @@ and libraries:
   engine.
 * :mod:`imgui.integrations.sdl2` integrates **pyimgui** with SDL2_ library
   through PySDL2_ Python package
-* :mod:`imgui.integrations.pyglet` integrates **pyimgui** with pyglet_ library.
+* :mod:`imgui.integrations.pyglet` integrates **pyimgui** with pyglet_
+  library, both stable (1.5.x) and development versions (2.x), switching
+  between *fixed* and *programmable* as appropriate.
 * :mod:`imgui.integrations.opengl` provides bare integration with OpenGL both
   in *fixed pipeline* and *programmable pipeline* mode. It does not provide any
   windowing facilities (so cannot be used as a standalone renderer) but serves

--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -105,10 +105,14 @@ class PygletRenderer(PygletMixin, ProgrammablePipelineRenderer):
     def __init__(self, window, attach_callbacks=True):
         super(PygletRenderer, self).__init__()
         window_size = window.get_size()
-        viewport_size = window.get_viewport_size()
-
         self.io.display_size = window_size
-        self.io.display_fb_scale = compute_fb_scale(window_size, viewport_size)
+
+        if hasattr(window, 'get_viewport_size'):
+            viewport_size = window.get_viewport_size()
+            self.io.display_fb_scale = compute_fb_scale(window_size, viewport_size)
+        else:
+            self.io.display_fb_scale = (window.get_pixel_ratio(), window.get_pixel_ratio())
+
 
         self._map_keys()
 

--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -6,7 +6,7 @@ from pyglet.window import key, mouse
 import imgui
 
 from . import compute_fb_scale
-from .opengl import FixedPipelineRenderer
+from .opengl import ProgrammablePipelineRenderer
 
 
 class PygletMixin(object):
@@ -101,7 +101,7 @@ class PygletMixin(object):
         self.io.display_size = width, height
 
 
-class PygletRenderer(PygletMixin, FixedPipelineRenderer):
+class PygletRenderer(PygletMixin, ProgrammablePipelineRenderer):
     def __init__(self, window, attach_callbacks=True):
         super(PygletRenderer, self).__init__()
         window_size = window.get_size()

--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import warnings
+from distutils.version import LooseVersion
 
 from pyglet.window import key, mouse
+import pyglet
 
 import imgui
 
 from . import compute_fb_scale
-from .opengl import ProgrammablePipelineRenderer
+from .opengl import FixedPipelineRenderer, ProgrammablePipelineRenderer
 
 
 class PygletMixin(object):
@@ -32,6 +35,37 @@ class PygletMixin(object):
         key.Y: imgui.KEY_Y,
         key.Z: imgui.KEY_Z,
     }
+
+    def _set_pixel_ratio(self, window):
+        window_size = window.get_size()
+        self.io.display_size = window_size
+        # It is conceivable that the pyglet version will not be solely
+        # determinant of whether we use the fixed or programmable, so do some
+        # minor introspection here to check.
+        if hasattr(window, 'get_viewport_size'):
+            viewport_size = window.get_viewport_size()
+            self.io.display_fb_scale = compute_fb_scale(window_size, viewport_size)
+        elif hasattr(window, 'get_pixel_ratio'):
+            self.io.display_fb_scale = (window.get_pixel_ratio(),
+                                        window.get_pixel_ratio())
+        else:
+            # Default to 1.0 in this unlikely circumstance
+            self.io.display_fb_scale = (1.0, 1.0)
+
+
+    def _attach_callbacks(self, window):
+        window.push_handlers(
+            self.on_mouse_motion,
+            self.on_key_press,
+            self.on_key_release,
+            self.on_text,
+            self.on_mouse_drag,
+            self.on_mouse_press,
+            self.on_mouse_release,
+            self.on_mouse_scroll,
+            self.on_resize,
+        )
+
 
     def _map_keys(self):
         key_map = self.io.key_map
@@ -100,31 +134,39 @@ class PygletMixin(object):
     def on_resize(self, width, height):
         self.io.display_size = width, height
 
-
-class PygletRenderer(PygletMixin, ProgrammablePipelineRenderer):
+class PygletFixedPipelineRenderer(PygletMixin, FixedPipelineRenderer):
     def __init__(self, window, attach_callbacks=True):
-        super(PygletRenderer, self).__init__()
-        window_size = window.get_size()
-        self.io.display_size = window_size
-
-        if hasattr(window, 'get_viewport_size'):
-            viewport_size = window.get_viewport_size()
-            self.io.display_fb_scale = compute_fb_scale(window_size, viewport_size)
-        else:
-            self.io.display_fb_scale = (window.get_pixel_ratio(), window.get_pixel_ratio())
-
-
+        super(PygletFixedPipelineRenderer, self).__init__()
+        self._set_pixel_ratio(window)
         self._map_keys()
+        if attach_callbacks: self._attach_callbacks(window)
 
-        if attach_callbacks:
-            window.push_handlers(
-                self.on_mouse_motion,
-                self.on_key_press,
-                self.on_key_release,
-                self.on_text,
-                self.on_mouse_drag,
-                self.on_mouse_press,
-                self.on_mouse_release,
-                self.on_mouse_scroll,
-                self.on_resize,
-            )
+class PygletProgrammablePipelineRenderer(PygletMixin, ProgrammablePipelineRenderer):
+    def __init__(self, window, attach_callbacks = True):
+        super(PygletProgrammablePipelineRenderer, self).__init__()
+        self._set_pixel_ratio(window)
+        self._map_keys()
+        if attach_callbacks: self._attach_callbacks(window)
+
+class PygletRenderer(PygletFixedPipelineRenderer):
+    def __init__(self, window, attach_callbacks=True):
+        warnings.warn("PygletRenderer is deprecated; please use either "
+                      "PygletFixedPipelineRenderer (for OpenGL 2.1, pyglet < 2.0) or "
+                      "PygletProgrammablePipelineRenderer (for later versions) or "
+                      "create_renderer(window) to auto-detect.",
+                      DeprecationWarning)
+        super(PygletRenderer, self).__init__(window, attach_callbacks)
+
+def create_renderer(window, attach_callbacks=True):
+    """
+    This is a helper function that wraps the appropriate version of the Pyglet
+    renderer class, based on the version of pyglet being used.
+    """
+    # Determine the context version
+    # Pyglet < 2.0 has issues with ProgrammablePipeline even when the context
+    # is OpenGL 3, so we need to check the pyglet version rather than looking
+    # at window.config.major_version to see if we want to use programmable.
+    if LooseVersion(pyglet.version) < LooseVersion('2.0'):
+        return PygletFixedPipelineRenderer(window, attach_callbacks)
+    else:
+        return PygletProgrammablePipelineRenderer(window, attach_callbacks)


### PR DESCRIPTION
Pyglet 2.0 in dev requires using the programmable pipeline, and pyglet 1.5 allows it.  This lets the in-dev pyglet version work with the pyglet integration with no additional changes.