### PR TITLE
Fixes Pyglet example code that causes draw updates to only happen while input occurs

### DIFF
--- a/doc/examples/integrations_pyglet.py
+++ b/doc/examples/integrations_pyglet.py
@@ -40,13 +40,13 @@ def main():
         imgui.text_colored("Eggs", 0.2, 1., 0.)
         imgui.end()
 
-    @window.event
-    def on_draw():
-        update(1/60.0)
+    def draw(dt):
+        update(dt)
         window.clear()
         imgui.render()
         impl.render(imgui.get_draw_data())
 
+    pyglet.clock.schedule_interval(draw, 1/120.)
     pyglet.app.run()
     impl.shutdown()
 


### PR DESCRIPTION
While testing the example code `integrations_pyglet.py` I noticed a bug. It only updates the screen while input occurs, which essentially means I have to be constantly moving my mouse in order to see fluid updates, otherwise the screen freezes on the last frame drawn. I have tested this on two seperate Linux computers, on Xorg and Wayland. 

Test this:
 * run `python integrations_pyglet.py`
 * In the demo window find `Popups and Modal Windows`, click `Popups`, and then click one of the buttons to open a pop up.
 * If you do not move your mouse when you click, the popup does not open, but as soon as you move your mouse, it does.

The same problem does not exist in other integrations like glfw. 

I searched for this, and apparently it is a common occurance with pyglet, see https://stackoverflow.com/questions/21060970/pyglet-on-draw-event-occurs-only-when-mouse-moves

So following the accepted answer there, I find that it does indeed fix the issue for me. I am sharing this PR as it is an easy fix, but I think it also may be a bug in pyglet? (I don't know.) Please close this PR if its supposed to work as-is. Thanks!