### PR TITLE
fix UnicodeDecodeError occurences in input_text_multiline

### DIFF
--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -276,7 +276,7 @@ cdef bytes _bytes(str text):
 
 
 cdef str _from_bytes(bytes text):
-    return <str>(text if PY_MAJOR_VERSION < 3 else text.decode('utf-8'))
+    return <str>(text if PY_MAJOR_VERSION < 3 else text.decode('utf-8', errors='ignore'))
 
 
 cdef _cast_ImVec2_tuple(cimgui.ImVec2 vec):  # noqa


### PR DESCRIPTION
When the `input_text_multiline` buffer cuts in the wrong place, this code was throwing a `UnicodeDecodeError` exception.

```
  File "imgui/core.pyx", line 4990, in imgui.core.input_text_multiline
  File "imgui/core.pyx", line 323, in imgui.core._from_bytes
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xde in position 10000: unexpected end of data
```
