### PR TITLE
Added mapping of ImGui::CalcTextSize

### DIFF
--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -1182,7 +1182,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     void SetStateStorage(ImGuiStorage* storage) except +  # ✗
     ImGuiStorage* GetStateStorage() except +  # ✗
 
-    ImVec2 CalcTextSize(  # ✗
+    ImVec2 CalcTextSize(  # ✓
             const char* text,
             # note: optional
             const char* text_end,

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -1846,7 +1846,6 @@ def render():
     """
     cimgui.Render()
 
-
 def show_user_guide():
     """Show ImGui user guide editor.
 
@@ -6649,6 +6648,43 @@ def pop_font():
     """
     cimgui.PopFont()
 
+cpdef calc_text_size(str text, bool hide_text_after_double_hash = False, float wrap_width = 0.0):
+    """Calculate text size. 
+    Text can be multi-line. 
+    Optionally ignore text after a ## marker.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 300
+        :height: 100
+
+        imgui.begin("Text size calculation")
+        text_content = "This is a ##text##!"
+        text_size1 = imgui.calc_text_size(text_content)
+        imgui.text('"%s" has size %ix%i' % (text_content, text_size1[0], text_size1[1]))
+        text_size2 = imgui.calc_text_size(text_content, True)
+        imgui.text('"%s" has size %ix%i' % (text_content, text_size2[0], text_size2[1]))
+        text_size3 = imgui.calc_text_size(text_content, False, 30.0)
+        imgui.text('"%s" has size %ix%i' % (text_content, text_size3[0], text_size3[1]))
+        imgui.end()
+
+    Args:
+        text (str): text
+        hide_text_after_double_hash (bool): if True, text after '##' is ignored
+        wrap_width (float): if > 0.0 calculate size using text wrapping
+    
+    .. wraps::
+        CalcTextSize(const char* text, const char* text_end, bool hide_text_after_double_hash, float wrap_width)
+    """
+    return _cast_ImVec2_tuple(
+        cimgui.CalcTextSize(
+            _bytes(text),
+            NULL,
+            hide_text_after_double_hash,
+            wrap_width
+        )
+    )
+
 cpdef push_style_var(cimgui.ImGuiStyleVar variable, value):
     """Push style variable on stack.
 
@@ -6884,7 +6920,6 @@ cpdef calculate_item_width():
         float CalcItemWidth()
     """
     return cimgui.CalcItemWidth()
-
 
 cpdef push_text_wrap_pos(float wrap_pos_x = 0.0):
     """Word-wrapping function for text*() commands.


### PR DESCRIPTION
ImGui function CalcTextSize() was not mapped yet. I mapped it since I needed it for one of my projects. 

This function takes a string and returns its size in pixels as a vector. It is possible to specify to ignore content after '##', and/or a wrapping width to use in computation.

I took the liberty to add default values for parameters `hide_text_after_double_hash` and `wrap_width` for quick call like: `imgui.calc_text_size("MyStr")` 