### PR TITLE
slider angle

### DIFF
--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -5367,6 +5367,54 @@ def input_double(
     ), inout_value
 
 
+def slider_angle(
+    str label,
+    float value,
+    float min_value,
+    float max_value,
+):
+    """Display angle slider widget.
+
+    .. visual-example::
+        :auto_layout:
+        :width: 400
+        :height: 130
+
+        value = 88.2
+
+        imgui.begin("Example: slider angle")
+        changed, value = imgui.slider_angle(
+            "slide angles", value,
+            min_value=0.0, max_value=100.0,
+        )
+        imgui.text("Changed: %s, Value: %s" % (changed, value))
+        imgui.end()
+
+    Args:
+        label (str): widget label.
+        value (float): slider values.
+        min_value (float): min value allowed by widget.
+        max_value (float): max value allowed by widget.
+
+    Returns:
+        tuple: a ``(changed, values)`` tuple that contains indicator of
+        widget state change and the current slider value.
+
+    .. wraps::
+        bool SliderAngle(
+            const char* label,
+            float v,
+            float v_min,
+            float v_max,
+        )
+    """
+    cdef float inout_value = value
+    return cimgui.SliderAngle(
+        _bytes(label), <float*>&inout_value,
+        min_value, max_value
+    ), inout_value
+
+
 
 def slider_float(
     str label,


### PR DESCRIPTION
Implements the slider angle control.

FYI -- I'm working on making python demo code that calls all of the imgui widgets via python, whereas pyimgui's demos currently defaults to calling the C++ implementation of the demos, which makes copying and pasting demo code difficult for Python programmers who may not know C++.  As part of this work of mine, I am implementing any missing controls, such as slider angle, and I plan to incrementally send over those implementations via PRs into master as I make them.

My implementation of the python-based demo is at https://github.com/billsix/pyimgui/tree/implementDemos .  Once I have implemented the full set, I plan to do a squash merge into master, and send the one final pull request for those demos.  The reason for this method is to to minimize commits of partial work that I make, which I expect to be 20+ commits of incomplete work, and instead provide 1 complete commit into your master.

However, a commit such as what I've attached is complete work, as it implements slider_control, so I believe that it should be in its own commit in master.

I just bought your book yesterday to support the good work that you are doing.  Thank you.