### PR TITLE
Fix horizontal mouse wheel callback

### DIFF
--- a/imgui/integrations/glfw.py
+++ b/imgui/integrations/glfw.py
@@ -98,6 +98,7 @@ class GlfwRenderer(ProgrammablePipelineRenderer):
         pass
 
     def scroll_callback(self, window, x_offset, y_offset):
+        self.io.mouse_wheel_horizontal = x_offset
         self.io.mouse_wheel = y_offset
 
     def process_inputs(self):

--- a/imgui/integrations/glumpy.py
+++ b/imgui/integrations/glumpy.py
@@ -143,6 +143,7 @@ class GlumpyRenderer(BaseOpenGLRenderer):
         pass
 
     def scroll_callback(self, window, x_offset, y_offset):
+        self.io.mouse_wheel_horizontal = x_offset
         self.io.mouse_wheel = y_offset
 
     def process_inputs(self):


### PR DESCRIPTION
As highlighted in #190, mouse ``scroll_callback()`` of _glfw_ and _glumpy_ was not doing anything with ``x_offset``. Fixed it to interact with the horizontal scrolling.

My mouse does not allow horizontal scrolling, I tested it by swapping x/y direction, and it seems to work fine. I don't see why it would be any different giving a real ``x_offset`` instead, but let me know if there are any problems.